### PR TITLE
Hub XMLRPC API RFC - alternatives and clarifications

### DIFF
--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -129,6 +129,8 @@ Alternatives that were considered come from:
 | apicast              | 56k    | Lua              |                                                   |
 | expressgateway       | 33k    | Javascript       |                                                   |
 
+Note: Lua projects are actually Nginx plugins.
+
 ## Features
 * Authorization and authentication
   * Alternative idea 1: a configuration file on the Hub contains a list of credentials and `serverIds`. Hub would automatically maintain a pool of Server `sessionKey`s from those credentials

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -33,7 +33,9 @@ Content management APIs will work as of today. Inter-Server Synchronization (ISS
 
 ### New service and endpoint
 A new XMLRPC API endpoint will be created, implemented by a new service called the "XMLRPC Gateway API" (simply called "Gateway" from now on in this document). Technology-wise:
-  * Implementation will be in Python based on top of Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/) library
+  * Implementation will either be (choice delegated to the implementation phase):
+    * in Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/) library, in order for the resulting program to use exclusively async I/O
+    * in Go, using goroutines to attain the same result
   * all I/O should be handled asynchronously via Tornado. Calls to several Servers should happen in parallel, with a maximum timeout value for unreachable/not responding Servers
   * there will be no backing database. All new methods will delegate to existing XMLRPC APIs (either the Hub's or individual Servers')
     - some kind of storage might be needed for performance/caching purposes, that is left as an implementation detail

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -33,11 +33,11 @@ Content management APIs will work as of today. Inter-Server Synchronization (ISS
 
 ### New service and endpoint
 A new XMLRPC API endpoint will be created, implemented by a new service called the "XMLRPC Gateway API" (simply called "Gateway" from now on in this document). Technology-wise:
-  * Implementation will be based on asynchronous I/O. The exact technology choice is delegated to the implementation phase and could be:
+  * Implementation will be based on asynchronous I/O. Calls to several Servers should happen concurrently  
+  * The exact technology choice is delegated to the implementation phase and could be:
     * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also used in core Salt
     * typed Python, based on the native [asyncio library](https://docs.python.org/3.6/library/asyncio.html) (new to 3.4, similar in intent to Tornado). Rationale: learning latest Python technologies
     * in Go, using goroutines. Rationale: learning Go
-  * all I/O should be handled asynchronously via Tornado. Calls to several Servers should happen in parallel, with a maximum timeout value for unreachable/not responding Servers
   * there will be no backing database. All new methods will delegate to existing XMLRPC APIs (either the Hub's or individual Servers')
     - some kind of storage might be needed for performance/caching purposes, that is left as an implementation detail
 

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -33,9 +33,10 @@ Content management APIs will work as of today. Inter-Server Synchronization (ISS
 
 ### New service and endpoint
 A new XMLRPC API endpoint will be created, implemented by a new service called the "XMLRPC Gateway API" (simply called "Gateway" from now on in this document). Technology-wise:
-  * Implementation will either be (choice delegated to the implementation phase):
-    * in Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/) library, in order for the resulting program to use exclusively async I/O
-    * in Go, using goroutines to attain the same result
+  * Implementation will be based on asynchronous I/O. The exact technology choice is delegated to the implementation phase and could be:
+    * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also used in core Salt
+    * typed Python, based on the native [asyncio library](https://docs.python.org/3.6/library/asyncio.html) (new to 3.4, similar in intent to Tornado). Rationale: learning latest Python technologies
+    * in Go, using goroutines. Rationale: learning Go
   * all I/O should be handled asynchronously via Tornado. Calls to several Servers should happen in parallel, with a maximum timeout value for unreachable/not responding Servers
   * there will be no backing database. All new methods will delegate to existing XMLRPC APIs (either the Hub's or individual Servers')
     - some kind of storage might be needed for performance/caching purposes, that is left as an implementation detail

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -35,7 +35,7 @@ Content management APIs will work as of today. Inter-Server Synchronization (ISS
 A new XMLRPC API endpoint will be created, implemented by a new service called the "XMLRPC Gateway API" (simply called "Gateway" from now on in this document). Technology-wise:
   * Implementation will be based on asynchronous I/O. Calls to several Servers should happen concurrently  
   * The exact technology choice is delegated to the implementation phase and could be:
-    * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also currently used in core Salt (rumored to be potentially replaced in future)
+    * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also currently used in core Salt (but rumored to be potentially replaced with [trio](https://github.com/python-trio/trio) in future)
     * typed Python, based on the native [asyncio library](https://docs.python.org/3.6/library/asyncio.html) (new to 3.4, similar in intent to Tornado). Rationale: learning latest Python technologies
     * in Go, using goroutines. Rationale: learning Go
   * there will be no backing database. All new methods will delegate to existing XMLRPC APIs (either the Hub's or individual Servers')

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -96,6 +96,37 @@ All code would be new in a new component, so no change to existing components is
 
 # Alternatives
 [alternatives]: #alternatives
+## Build on an existing API gateway
+
+Several open source project exist that offer API gateway functionality on any kind of network API (often in practice limited to http protocols). Those projects typically offer a range of functionalities such as configurable retry patterns, additional security checks, logging, monitoring, rate limiting, circuit breaking, caching and in some cases API aggregations and manipulation of requests and responses. In several cases, such engines provide plugin mechanisms or anyway lend themselves to implementation of ad-hoc modules that could fit in the requirements from this RFC. Summarizing:
+ - pros: potentially many features would be provided by such tools. Only automatic retrying is required at this point, but others might also become relevant in future
+ - cons: code bases are typically much bigger than the expected size of this project (1K - 2K LOC), and the type of request modifications required will still need they have to be implemented as plugins/extensions, which might lead to an approximately-similar coding effort
+
+Alternatives that were considered come from:
+ - GitHub projects with at least 1000 stars
+ - [the CNCF category](https://landscape.cncf.io/category=api-gateway&format=card-mode&grouping=category)
+ - a list provided as comment to the original version of this RFC
+ 
+| Name                 | LOC    | Main languages   | Notes                                             |
+|----------------------|--------|------------------|---------------------------------------------------|
+| gravitee             | 500k   | Java, TypeScript | Supports MongoDB, Redis, ElasticSearch...         |
+| tyk                  | 100k   | Go               | No request modification support, security only    |
+| wso2                 | 5.636M | Java             | 28 main git repos                                 |
+| apiman               | 225k   | Java, TypeScript |                                                   |
+| krakend              | 63k    | Go               | 41 git repos                                      |
+| kong                 | 156k   | Lua              |                                                   |
+| ocelot               | 55k    | C#               |                                                   |
+| gateway              | 46k    | Go               |                                                   |
+| spring-cloud-gateway | 39k    | Java             |                                                   |
+| janus                | 20k    | Go               | No request modification support, maintenance mode |
+| gloo                 | 202k   | Go               |                                                   |
+| goku                 | 183k   | Go               |                                                   |
+| api-umbrella         | 105k   | ruby             |                                                   |
+| apisix               | 18k    | Lua              |                                                   |
+| apicast              | 56k    | Lua              |                                                   |
+| expressgateway       | 33k    | Javascript       |                                                   |
+
+## Features
 * Authorization and authentication
   * Alternative idea 1: a configuration file on the Hub contains a list of credentials and `serverIds`. Hub would automatically maintain a pool of Server `sessionKey`s from those credentials
     * `hub.login(username, password)` → `hubSessionKey`

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -102,7 +102,7 @@ All code would be new in a new component, so no change to existing components is
 [alternatives]: #alternatives
 ## Build on an existing API gateway
 
-Several open source project exist that offer API gateway functionality on any kind of network API (often in practice limited to http protocols). Those projects typically offer a range of functionalities such as configurable retry patterns, additional security checks, logging, monitoring, rate limiting, circuit breaking, caching and in some cases API aggregations and manipulation of requests and responses. In several cases, such engines provide plugin mechanisms or anyway lend themselves to implementation of ad-hoc modules that could fit in the requirements from this RFC. Summarizing:
+Several open source projects exist that offer API gateway functionality on any kind of network API (often, in practice, http-based protocols). Those projects typically offer a range of functionalities such as configurable retry patterns, additional security features, logging, monitoring, rate limiting, circuit breaking, caching and in some cases API aggregations and manipulation of requests and responses. In several cases, such engines provide plugin mechanisms or anyway lend themselves to implementation of ad-hoc modules that could fit in the requirements from this RFC. Summarizing:
  - pros: potentially many features would be provided by such tools. Only automatic retrying is required at this point, but others might also become relevant in future
  - cons: code bases are typically much bigger than the expected size of this project (1K - 2K LOC), and the type of request modifications required will still need they have to be implemented as plugins/extensions, which might lead to an approximately-similar coding effort
 
@@ -111,25 +111,24 @@ Alternatives that were considered come from:
  - [the CNCF category](https://landscape.cncf.io/category=api-gateway&format=card-mode&grouping=category)
  - a list provided as comment to the original version of this RFC
  
-| Name                 | LOC    | Main languages   | Notes                                             |
-|----------------------|--------|------------------|---------------------------------------------------|
-| gravitee             | 500k   | Java, TypeScript | Supports MongoDB, Redis, ElasticSearch...         |
-| tyk                  | 100k   | Go               | No request modification support, security only    |
-| wso2                 | 5.636M | Java             | 28 main git repos                                 |
-| apiman               | 225k   | Java, TypeScript |                                                   |
-| krakend              | 63k    | Go               | 41 git repos                                      |
-| kong                 | 156k   | Lua              |                                                   |
-| ocelot               | 55k    | C#               |                                                   |
-| gateway              | 46k    | Go               |                                                   |
-| spring-cloud-gateway | 39k    | Java             |                                                   |
-| janus                | 20k    | Go               | No request modification support, maintenance mode |
-| gloo                 | 202k   | Go               |                                                   |
-| goku                 | 183k   | Go               |                                                   |
-| api-umbrella         | 105k   | ruby             |                                                   |
-| apisix               | 18k    | Lua              |                                                   |
-| apicast              | 56k    | Lua              |                                                   |
-| expressgateway       | 33k    | Javascript       |                                                   |
-
+| Name                                                                                        | LOC    | Main languages   | Notes                                             |
+|---------------------------------------------------------------------------------------------|--------|------------------|---------------------------------------------------|
+| [gravitee](https://gravitee.io/products/apim/)                                              | 500k   | Java, TypeScript | Supports MongoDB, Redis, ElasticSearch...         |
+| [tyk](https://tyk.io/features/features/)                                                    | 100k   | Go               | No request modification support, security only    |
+| [wso2](https://wso2.com/api-management/features/)                                           | 5.636M | Java             | 28 main git repos                                 |
+| [apiman](http://www.apiman.io/latest/)                                                      | 225k   | Java, TypeScript |                                                   |
+| [krakend](https://www.krakend.io/features/)                                                 | 63k    | Go               | 41 git repos                                      |
+| [kong](https://konghq.com/kong/)                                                            | 156k   | Lua              |                                                   |
+| [ocelot](https://ocelot.readthedocs.io/en/latest/introduction/gettingstarted.html)          | 55k    | C#               |                                                   |
+| [gateway](https://github.com/fagongzi/gateway#features)                                     | 46k    | Go               |                                                   |
+| [spring-cloud-gateway](https://github.com/spring-cloud/spring-cloud-gateway#features)       | 39k    | Java             |                                                   |
+| [janus](https://github.com/hellofresh/janus#key-features)                                   | 20k    | Go               | No request modification support, maintenance mode |
+| [gloo](https://docs.solo.io/gloo/latest/introduction/whygloo/)                              | 202k   | Go               |                                                   |
+| [goku](https://github.com/eolinker/goku-api-gateway/blob/master/README.md#product-features) | 183k   | Go               |                                                   |
+| [api-umbrella](https://apiumbrella.io/)                                                     | 105k   | ruby             |                                                   |
+| [apisix](https://github.com/apache/incubator-apisix#features)                               | 18k    | Lua              |                                                   |
+| [apicast](https://github.com/3scale/apicast#features)                                       | 56k    | Lua              |                                                   |
+| [expressgateway](https://github.com/expressgateway/express-gateway#main-features)           | 33k    | Javascript       |                                                   |
 Note: Lua projects are actually Nginx plugins.
 
 ## Features

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -35,7 +35,7 @@ Content management APIs will work as of today. Inter-Server Synchronization (ISS
 A new XMLRPC API endpoint will be created, implemented by a new service called the "XMLRPC Gateway API" (simply called "Gateway" from now on in this document). Technology-wise:
   * Implementation will be based on asynchronous I/O. Calls to several Servers should happen concurrently  
   * The exact technology choice is delegated to the implementation phase and could be:
-    * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also used in core Salt
+    * typed Python, based on Tornado and [tornado-xmlrpc](https://pypi.org/project/tornado-xmlrpc/). Rationale: learning Tornado, which is also currently used in core Salt (rumored to be potentially replaced in future)
     * typed Python, based on the native [asyncio library](https://docs.python.org/3.6/library/asyncio.html) (new to 3.4, similar in intent to Tornado). Rationale: learning latest Python technologies
     * in Go, using goroutines. Rationale: learning Go
   * there will be no backing database. All new methods will delegate to existing XMLRPC APIs (either the Hub's or individual Servers')

--- a/accepted/00062-hub-xmlrpc-api.md
+++ b/accepted/00062-hub-xmlrpc-api.md
@@ -75,7 +75,8 @@ Idea is to expose existing Server XMLRPC endpoints/methods as they are on the Hu
     * special elements would be needed to signal Exceptions
 
 * Availability
-  * if a Server is down at the time a Gateway call targeting it is made, call should fail after a configurable timeout. If multiple Servers are targeted, only that call fails and others continue
+  * if a Server is down at the time a Gateway call targeting it is made, call should fail after a configurable timeout. If multiple Servers are targeted, only that call fails and others continue.
+  * the timeout should have a default value configured via a file or environment variable, overridable on a per-call basis (eg. extra parameter)
 
 
 ## Impact on existing components and users


### PR DESCRIPTION
This PR is to address two comments on the first text that was merged:

 - describing alternatives to writing from scratch
 - clarify how the retry mechanism can be configured
 - defer the programming language choice