### PR TITLE
RFC: native LDAP authentication

### DIFF
--- a/accepted/00000-native-ldap-authentication.md
+++ b/accepted/00000-native-ldap-authentication.md
@@ -1,0 +1,269 @@
+- Feature Name: native_ldap_authentication
+- Start Date: 2026-06-04
+
+# Summary
+[summary]: #summary
+
+Add a native, Java-based LDAP/Active Directory authentication provider to Uyuni's web application. Administrators configure the directory connection from Uyuni itself instead of relying on the host operating system (SSSD/PAM) or a reverse proxy. A successful LDAP login can optionally create or update the Uyuni user, and LDAP group membership is mapped to Uyuni roles by reusing the existing external group mapping tables (`rhnUserExtGroup` / `rhnUserExtGroupMapping`) and the temporary-role lifecycle already used for header-based external authentication.
+
+# Motivation
+[motivation]: #motivation
+
+Today Uyuni can authenticate against a directory only indirectly:
+
+- **PAM/SSSD**: the host OS is configured for LDAP and Uyuni delegates the password check to PAM (`WEB_PAM_AUTH_SERVICE` plus a per-user `usePamAuthentication` flag). The directory configuration lives in `sssd.conf`, edited over the CLI, outside Uyuni.
+- **Header-based external auth** (`REMOTE_USER`): a frontend web server or IdP authenticates the user and passes identity and group headers, which Uyuni trusts (`LoginHelper.checkExternalAuthentication`).
+
+In both cases the directory integration is invisible to Uyuni: an administrator cannot configure, test, or troubleshoot it from the product, and there is no managed concept of an "LDAP group" inside Uyuni. The external group string is consumed transiently during a `REMOTE_USER` login and then discarded.
+
+This feature brings directory integration into Uyuni so that an administrator can point Uyuni at an Active Directory, FreeIPA, or OpenLDAP server, optionally enable just-in-time user creation, map a directory group such as `uyuni-admins` to the Org Admin role, and have those users log in with the right roles without touching `sssd.conf`. Local Uyuni users continue to work unchanged.
+
+# Detailed design
+[design]: #detailed-design
+
+## Existing authentication flow
+
+```text
+Browser / API client
+  -> LoginController.performLogin()
+     -> LoginHelper.checkExternalAuthentication()        (REMOTE_USER header path)
+     -> if no external user:
+        -> UserManager.loginUser(login, password)
+           -> UserFactory.lookupByLogin(login)
+           -> UserImpl.authenticate(password)
+              -> PAM   (if WEB_PAM_AUTH_SERVICE set and user.usePamAuthentication)
+              -> local DB password check otherwise
+     -> LoginHelper.successfulLogin()
+```
+
+The design reuses two existing patterns rather than reinventing them:
+
+- The **PAM service/factory shape** (`PamServiceFactory` → `DefaultPamServiceFactory` → `PamServiceWrapper`) is the structural template for isolating an external credential check behind a factory.
+- The **external-auth lifecycle** in `LoginHelper` already performs just-in-time user creation (`CreateUserCommand`), profile updates (`UpdateUserCommand`), external group to role mapping (`UserGroupFactory.lookupExtGroupByLabel`), and temporary-role assignment. This is the model for the LDAP user and role lifecycle.
+
+A standalone proof of concept (UnboundID LDAP SDK 7.0.4, Java 17) was run against a seeded OpenLDAP fixture to confirm the operations the design depends on: service-account bind, pooled connections, user search, group resolution by `(member=<userDN>)` without a `memberOf` overlay, a successful credential bind, and rejection of invalid credentials.
+
+## Proposed architecture
+
+LDAP authentication is implemented as a service behind a factory (mirroring PAM), with the user lifecycle handled at the login orchestration layer so just-in-time provisioning and role mapping are possible:
+
+```text
+LdapServiceFactory            (selects the configured implementation; testable seam)
+  -> LdapAuthenticationService
+       -> LdapConnectionProvider   (UnboundID LDAPConnectionPool, TLS, timeouts, failover)
+       -> LdapUserResolver         (bind/search/bind, attribute extraction)
+       -> LdapGroupResolver        (member= search and/or memberOf, normalization)
+  -> LdapLoginAdapter            (maps the LDAP result onto CreateUserCommand /
+                                  UpdateUserCommand / UserManager.resetTemporaryRoles)
+```
+
+Class names are indicative; the responsibilities are the design contract: connection handling, user lookup, group lookup, and mapping onto the Uyuni user lifecycle.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser/API
+    participant UM as UserManager.loginUser
+    participant LS as LdapAuthenticationService
+    participant DIR as LDAP/AD server
+    participant LA as LdapLoginAdapter
+    participant DB as PostgreSQL
+
+    B->>UM: login + password
+    UM->>UM: lookupByLogin(login)
+    alt local user and valid local password
+        UM->>DB: local DB password check -> success
+    else native LDAP
+        UM->>LS: authenticate(login, password)
+        LS->>DIR: service bind, search user, bind as user DN, resolve groups
+        LS-->>UM: identity + attributes + group labels
+        UM->>LA: provision/update user, map groups
+        LA->>DB: web_contact + rhnUserGroupMembers (temporary='Y')
+    else PAM
+        UM->>UM: UserImpl PAM branch
+    end
+    UM->>B: successfulLogin(user)
+```
+
+## Login ordering
+
+The credential resolution order for username/password login is **Local DB → Native LDAP → PAM**. Concretely, in `UserManager.loginUser` (after the `REMOTE_USER` external-auth check that already runs first in `LoginController`):
+
+1. Look up the user by login. If a local user exists, has a usable local password, and that password verifies, log in locally.
+2. Otherwise attempt native LDAP (bind/search/bind). On success, provision or update the user, map groups to temporary roles, and log in.
+3. Otherwise attempt PAM (unchanged).
+4. Otherwise fail with a single generic message (see Failure modes).
+
+This ordering is why the LDAP step lives at the orchestration layer and not inside `UserImpl.authenticate()`: step 2 may need to create a user that does not yet exist locally, while `UserImpl.authenticate()` runs only after `UserFactory.lookupByLogin()` has found one.
+
+## LDAP authentication flow
+
+The provider uses the standard bind/search/bind sequence:
+
+1. Bind with the configured service account (or anonymous bind if explicitly enabled).
+2. Search for the user under the configured base DN using the configured filter; require **exactly one** match.
+3. Bind as the discovered user DN with the password supplied at login.
+4. Resolve the user's groups.
+5. Return the normalized login, profile attributes, and group labels to the lifecycle adapter.
+
+User input is never concatenated into a filter; values are escaped (the POC uses `Filter.createEqualityFilter`, which escapes automatically). Selecting the server type pre-fills attribute and filter defaults (AD vs. IPA/POSIX), so administrators rarely type raw attribute names:
+
+```text
+ldap.server_type        = ACTIVE_DIRECTORY        # or FREE_IPA / OPENLDAP / POSIX
+ldap.url                = ldaps://ad.example.com:636
+ldap.bind_dn            = CN=uyuni-reader,OU=Service,DC=example,DC=com
+ldap.user_base_dn       = OU=Users,DC=example,DC=com
+ldap.user_filter        = (&(objectClass=user)(sAMAccountName={login}))
+ldap.login_attribute    = sAMAccountName           # uid for FreeIPA/OpenLDAP/POSIX
+ldap.group_base_dn      = OU=Groups,DC=example,DC=com
+ldap.group_filter       = (&(objectClass=group)(member={userDn}))
+ldap.group_name_attribute = cn
+ldap.provisioning_mode  = JIT                      # default; EXISTING_ONLY opt-in
+ldap.default_org_id     = 1
+```
+
+## User provisioning
+
+Two modes, controlled by `provisioning_mode`:
+
+- **JIT** (default): a successful LDAP login creates the Uyuni user if absent, reusing `CreateUserCommand` exactly as `LoginHelper.newRemoteUser` does today (login set, non-usable placeholder password, attributes, org, temporary roles).
+- **EXISTING_ONLY**: LDAP authenticates only users that already exist in `web_contact`.
+
+JIT is the default because the project goal and the Satellite/Foreman precedent both assume directory users can log in without a pre-created account, and Uyuni already implements this lifecycle for external auth. When JIT is enabled, the UI requires a valid `default_org_id`, mirroring the existing `EXTAUTH_DEFAULT_ORGID` behavior. Attribute- or group-based org mapping is a later enhancement. `EXISTING_ONLY` remains available for deployments that require manual user creation first.
+
+On each successful login, selected profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`, as `updateRemoteUser` does; missing LDAP attributes do not overwrite existing Uyuni values.
+
+## Group resolution and role mapping
+
+The portable baseline is a group-side search, which the POC confirmed works without a server-side `memberOf` overlay:
+
+```text
+(&(objectClass=groupOfNames)(member=<userDN>))     # OpenLDAP / generic
+(&(objectClass=group)(member=<userDN>))            # Active Directory
+```
+
+`memberOf` on the user entry is supported as an optional optimization where the directory exposes it. Group labels are normalized to a configured attribute (default `cn`), with full-DN matching available where simple names are ambiguous. Nested groups are AD-specific (matching-rule OID `1.2.840.113556.1.4.1941`) and are deferred to a later iteration.
+
+Role mapping reuses the existing external group mechanism rather than introducing a new model. `rhnUserGroup` remains the role-assignment model; `rhnUserExtGroup` / `rhnUserExtGroupMapping` are dormant but reusable; `access.accessGroup` is the authorization layer for new endpoints, not the LDAP role target.
+
+```text
+LDAP groups
+  -> normalize to external group labels
+  -> UserGroupFactory.lookupExtGroupByLabel(label)   (rhnUserExtGroup -> rhnUserExtGroupMapping)
+  -> resolve org-scoped rhnUserGroup rows (the roles)
+  -> assign as temporary roles (CreateUserCommand/UpdateUserCommand.setTemporaryRoles)
+  -> on each login, UserManager.resetTemporaryRoles recomputes the set
+```
+
+Manually assigned permanent roles are never removed by LDAP login; only temporary (LDAP-derived) roles are recomputed, so a user removed from a directory group loses the corresponding Uyuni role on next login. The existing `EXTAUTH_KEEP_TEMPROLES` switch (`UserExternalHandler.setKeepTemporaryRoles`) governs whether temporary roles survive a later non-LDAP login.
+
+This also promotes the LDAP group to a first-class, managed entity: the `rhnUserExtGroup` row becomes the persisted representation of a known LDAP group, optionally scoped to a specific server (see Database design), managed from the Admin UI/API. The existing `REMOTE_USER` path is left untouched in v1; the LDAP adapter calls the same `LoginHelper.getRolesFromExtGroups()` resolution, and integration tests cover these previously dormant paths.
+
+## RBAC integration
+
+The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) is used only to protect the new LDAP configuration endpoints: the setup pages and API methods are registered in the RBAC endpoint mapping[^3] so only privileged administrators can read or change LDAP configuration. LDAP-derived user roles continue to flow through `rhnUserGroup`. Automatic population of `access.accessGroup` from LDAP groups is out of scope for v1.
+
+## Database design
+
+Reused tables:
+
+| Table | Use |
+| --- | --- |
+| `web_contact` | user identity; JIT users get a non-usable placeholder password |
+| `rhnUserGroup` / `rhnUserGroupType` | org-scoped role instances (unchanged) |
+| `rhnUserGroupMembers` | role membership; `temporary='Y'` for LDAP-derived roles |
+| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role mapping (revived) |
+| `suseCredentials` | bind password, via a new `ldap` credential type (see below) |
+
+One new entity (working name `suseLdapAuthServer`, one row per configured directory) holds the connection and mapping configuration. Rather than fix the exact columns, types, and constraints now, the design captures the data the entity must hold, grouped by purpose; the concrete schema is settled during implementation:
+
+- **Connection** - label, enabled flag, server type, host, port, transport, and a connect/response timeout. Server type (`ACTIVE_DIRECTORY` / `FREE_IPA` / `OPENLDAP` / `POSIX`) and transport (`LDAPS` / `STARTTLS` / `PLAIN`) are modeled as Java enums, as CoCo attestation models `env_type`[^6].
+- **Bind account** - the service-account bind DN (null meaning anonymous bind) and a reference to the stored bind password (see below).
+- **User lookup** - user base DN, user search filter, login attribute, and optional first-name, last-name, and email attributes.
+- **Group lookup** - group base DN, group filter, group-name attribute (default `cn`), a `memberOf` toggle, and an optional pre-authentication scope filter.
+- **Provisioning** - provisioning mode (`JIT` / `EXISTING_ONLY`) and the default org applied to JIT-created users.
+
+This entity is the single source of truth for a directory, and the enum-backed fields keep server-type and transport handling type-safe in Java rather than relying on free-form strings.
+
+To make external groups first-class and optionally LDAP-scoped, the design adds a nullable reference from `rhnUserExtGroup` to the new directory entity. A null value preserves today's server-agnostic behavior (used by `REMOTE_USER`); a set value scopes the mapping to one directory. Modeling this as a nullable link on the existing table, rather than a parallel new table, avoids duplicating the established external-group mechanism.
+
+The **bind password** is stored in `suseCredentials` under a new `ldap` credential type, reusing the `PasswordBasedCredentials` pattern already used for SCC, registry, and cloud-RMT credentials (Base64-encoded at rest). In practice this adds an `ldap` type to the credential model and a corresponding credentials entity; the password is write-only in the UI/API, as SCC credentials are. Whether Base64-at-rest is sufficient or stronger encryption is required is left open below.
+
+## Transport security
+
+Production deployments must use encrypted transport (`LDAPS` or `STARTTLS`); `PLAIN` is allowed only for explicit dev/test. Trust material is validated against the JVM trust store. Because the server container already mounts CA anchors at `/etc/pki/trust/anchors/`, administrators can add the directory CA there or upload it through the UI. The exact integration is left open below.
+
+## Connection handling
+
+A pooled service connection (`LDAPConnectionPool`, validated in the POC) is used for searches, and a short-lived dedicated connection is used for each user credential bind. A connect/response timeout of 3–5s ensures an unreachable directory fails fast. Multiple servers can be combined via UnboundID's `FailoverServerSet` for HA in a later iteration.
+
+## Failure modes
+
+| Situation | Behavior |
+| --- | --- |
+| Active session, LDAP goes down | Unaffected; LDAP is checked only at login, never mid-session |
+| Local user logs in, LDAP down | Unaffected; local auth is first and independent |
+| LDAP user logs in, LDAP unreachable | Fail after the timeout; show "invalid credentials or directory unreachable, try again later" |
+| LDAP user, wrong password | Reject (invalid credentials) |
+| LDAP user also has a local password | No silent fallback to local after LDAP failure |
+| User search returns 0 or >1 entries | Treat as authentication failure (ambiguous) |
+| Group lookup fails after successful bind | Authenticate, assign no LDAP-derived roles, log the failure |
+| User maps to no Uyuni roles | Login succeeds with no temporary roles |
+
+The generic failure message intentionally does not distinguish "user unknown" from "wrong password" from "server down" to avoid user enumeration; details go to the server log.
+
+## User interface and API
+
+A new **Admin -> Setup -> LDAP** area follows Satellite's proven four-tab layout: **Server** (host, port, transport, type), **Account** (bind DN/password, base DNs, filters, provisioning mode, default org), **Attribute mappings** (login/name/email/group attributes, pre-filled from server type), and **User Groups** (external group to role bindings, extending the existing `ExtGroupDetailAction` UI). Three test actions give immediate feedback before LDAP is enabled and map directly onto POC operations: test connection (service bind), test user lookup (search), and test group resolution. A freshly provisioned user with no mapped groups logs in with no permissions until a mapping matches.
+
+Both API interfaces are provided, following the HTTP API RFC convention: the existing `user.external` XML-RPC namespace (`UserExternalHandler`) is extended for group-to-role mappings, a new `auth.ldap` namespace handles server CRUD and the test operations, and the same handlers are auto-exposed over JSON via the Spark route wrapper.
+
+## Phasing
+
+1. **Backend authentication** - `LdapServiceFactory` + `LdapAuthenticationService`, bind/search/bind, Local -> LDAP -> PAM ordering, minimal config, unit + integration tests against the fixture.
+2. **Provisioning + roles** - JIT user creation, profile sync, group-to-role mapping via `rhnUserExtGroup`, temporary-role reset.
+3. **UI + API** - four-tab Admin UI, test actions, XML-RPC + JSON endpoints, RBAC registration.
+4. **Advanced** - auth-source filter, multiple servers/failover, `memberOf` and AD nested groups.
+
+## Testing
+
+A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-users`) backs integration tests, seeded from the existing POC. Unit tests cover filter construction/escaping, attribute mapping, group normalization, role mapping, and temporary-role reset. Regression tests confirm local and PAM logins and the ordering are unaffected. Note: the core test tree currently has pre-existing compile breakage (`RhnMockHttpServletHttpServletResponse`, `SimpleTestingResponse`); whether it is fixed as part of this work is for the maintainers to decide.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- It adds code to a security-sensitive path; mistakes in ordering, fallback, filter escaping, or mapping could cause auth/authz bugs.
+- It introduces a runtime dependency on an external directory; timeouts and failure modes must be disciplined.
+- It likely adds a new third-party Java dependency (UnboundID LDAP SDK) that must clear licensing/packaging review.
+- It revives dormant `rhnUserExtGroup` code that may need repair and test coverage.
+- LDAP/AD deployments vary widely; v1 must choose clear defaults and document its limits rather than support every schema.
+
+# Alternatives
+[alternatives]: #alternatives
+
+- **Stay on PAM/SSSD only** - no new code, but no in-product configuration, testing, profile sync, or group-to-role mapping. Does not meet the goal.
+- **Improve only header-based `REMOTE_USER`** - keeps authentication outside Uyuni and still requires a proxy or IdP, with no in-product visibility. The Spacewalk/IPA integration[^4] is the precedent for this approach and its limits.
+- **LDAP only inside `UserImpl.authenticate()`** - minimal and mirrors the PAM branch, but cannot do first-login provisioning because user lookup precedes authentication; viable only for an `EXISTING_ONLY` build.
+- **Implementation-level choices** - for the LDAP client library, JNDI avoids a third-party dependency but is lower-level with harder pooling, StartTLS, and testability, while Apache Directory LDAP API and Spring LDAP are further candidates; the UnboundID SDK[^9] is the baseline pending licensing review. For bind-password storage, a plain column on `suseLdapAuthServer` or a container-level secret were considered but rejected in favor of the existing `suseCredentials` pattern for consistency with how Uyuni already stores SCC and registry secrets.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+1. **Secret and trust material** - is Base64-at-rest (as for SCC/registry credentials) acceptable for the bind password, or is encryption required, and where should the directory CA live: the JVM trust store, the container's `/etc/pki/trust/anchors/`, or an upload-through-UI flow?
+2. **Scoping external groups to a server** - is the nullable `rhnUserExtGroup.ldap_server_id` FK the right approach, or should mappings stay server-agnostic?
+3. **Superuser reachability** - may an LDAP group grant the top-level admin role, or should the highest privileges remain local-only?
+4. **Org assignment for JIT users** - is a single configured default org enough for v1, or is attribute-/group-based mapping needed early?
+5. **`access.accessGroup` future** - should the RFC commit to a later phase mapping LDAP groups into the new RBAC access groups, or leave it out of scope?
+6. **Primary target directory** - which directory is the primary path for the test matrix and docs: Active Directory, FreeIPA, or OpenLDAP?
+
+# References
+[references]: #references
+
+[^1]: Uyuni RFC template - https://github.com/uyuni-project/uyuni-rfc/blob/master/00000-template.md
+[^2]: RBAC RFC PR #95 - https://github.com/uyuni-project/uyuni-rfc/pull/95
+[^3]: RBAC endpoint mapping wiki - https://github.com/uyuni-project/uyuni/wiki/RBAC-Endpoint-Mapping
+[^4]: Spacewalk and IPA integration - https://github.com/spacewalkproject/spacewalk/wiki/SpacewalkAndIPA
+[^5]: CVE auditing with OVAL RFC - https://github.com/uyuni-project/uyuni-rfc/blob/master/accepted/00098-cve-auditing-with-oval.md
+[^6]: Confidential Compute Attestation RFC - https://github.com/uyuni-project/uyuni-rfc/blob/master/accepted/00100-coco-attestation.md
+[^7]: HTTP API RFC - https://github.com/uyuni-project/uyuni-rfc/blob/master/accepted/00088-http-api.md
+[^8]: LDAP Authentication in Satellite 6 (UX reference) - https://www.youtube.com/watch?v=gJAeRSE2IjQ
+[^9]: UnboundID LDAP SDK - https://github.com/pingidentity/ldapsdk

--- a/accepted/00000-native-ldap-authentication.md
+++ b/accepted/00000-native-ldap-authentication.md
@@ -6,6 +6,15 @@
 
 Add a native, Java-based LDAP/Active Directory authentication provider to Uyuni's web application. Administrators configure the directory connection from Uyuni itself instead of relying on the host operating system (SSSD/PAM) or a reverse proxy. A successful LDAP login can optionally create or update the Uyuni user, and LDAP group membership is mapped to Uyuni roles by reusing the existing external group mapping tables (`rhnUserExtGroup` / `rhnUserExtGroupMapping`) and the temporary-role lifecycle already used for header-based external authentication.
 
+## At a glance
+
+- **Admin value** — configure, test, and troubleshoot LDAP from Uyuni; map directory groups to Uyuni roles.
+- **Unchanged** — local DB users, per-user PAM users, and header-based `REMOTE_USER` auth.
+- **Login orchestration** — `LoginController` → `LoginHelper` (same layer as `checkExternalAuthentication`), not inside `UserManager.loginUser`.
+- **Per-user routing** — `auth_type` on `rhnUserInfo` (`LOCAL` / `PAM` / `LDAP`); no cascade between backends for known users.
+- **JIT** — unknown logins probe configured LDAP servers (priority order); on success, create the user with `auth_type = LDAP`.
+- **Out of scope for v1** — nested AD groups, `access.accessGroup` population from LDAP, multi-server HA failover.
+
 # Motivation
 [motivation]: #motivation
 
@@ -21,7 +30,7 @@ This feature brings directory integration into Uyuni so that an administrator ca
 # Detailed design
 [design]: #detailed-design
 
-## Existing authentication flow
+## Existing authentication flow (today)
 
 ```text
 Browser / API client
@@ -36,66 +45,98 @@ Browser / API client
      -> LoginHelper.successfulLogin()
 ```
 
+Native LDAP extends this at the same orchestration layer: after `checkExternalAuthentication`, a new `checkLdapAuthentication` step handles directory users and JIT provisioning before `UserManager.loginUser` is called for `LOCAL` / `PAM` users only (see Login routing).
+
 The design reuses two existing patterns rather than reinventing them:
 
 - The **PAM service/factory shape** (`PamServiceFactory` → `DefaultPamServiceFactory` → `PamServiceWrapper`) is the structural template for isolating an external credential check behind a factory.
-- The **external-auth lifecycle** in `LoginHelper` already performs just-in-time user creation (`CreateUserCommand`), profile updates (`UpdateUserCommand`), external group to role mapping (`UserGroupFactory.lookupExtGroupByLabel`), and temporary-role assignment. This is the model for the LDAP user and role lifecycle.
-
-A standalone proof of concept (UnboundID LDAP SDK 7.0.4, Java 17) was run against a seeded OpenLDAP fixture to confirm the operations the design depends on: service-account bind, pooled connections, user search, group resolution by `(member=<userDN>)` without a `memberOf` overlay, a successful credential bind, and rejection of invalid credentials. The POC was then extended to exercise the full proposed pipeline end to end (search, credential bind, group resolution, group-label-to-role-type mapping mirroring `LoginHelper.getRolesFromExtGroups`, and the just-in-time provisioning decision) for both a new directory-only user and an existing local user. This validated three design-critical assumptions and surfaced one gap: (a) the external-group mapping path is live, not dormant; (b) mapping is at the role-*type* level with org scoping already present on `rhnUserExtGroup`; (c) the reusable lifecycle methods in `LoginHelper` are currently `private` and must be extracted; and (d) profile attributes such as `givenName` are not guaranteed on `inetOrgPerson` entries, so first-name mapping needs a fallback. A second pass confirmed the remaining reuse claims against code: the `PasswordBasedCredentials` Base64-at-rest pattern and `CredentialsType` enum, the `PamServiceFactory` interface plus default implementation and wrapper (the structural template), and `UserManager.resetTemporaryRoles` as the shared temporary-role reset used by both `CreateUserCommand` and `UpdateUserCommand`. The one schema subtlety found in that pass is the `suseCredentials` `cred_type_check` constraint, discussed under Database design.
-
-**Scope of validation.** To be precise about what this evidence does and does not cover: the POC ran against **OpenLDAP only**, over **plain LDAP** (no TLS), as a **standalone simulation** of the orchestration logic. It did not run against Active Directory or FreeIPA, did not exercise LDAPS/StartTLS or trust-store validation, did not test anonymous bind or the `memberOf` path (only group-side `member=` search), and was not wired into the real `UserManager.loginUser` flow or `CreateUserCommand` against a live database. Those paths are designed from code reading and precedent, not yet executed; the unresolved questions below call out the ones that carry risk.
+- The **external-auth lifecycle** in `LoginHelper` already performs just-in-time user creation (`CreateUserCommand`), profile updates (`UpdateUserCommand`), external group to role mapping (`UserGroupFactory.lookupExtGroupByLabel`), and temporary-role assignment. Native LDAP follows this same lifecycle via a new `checkLdapAuthentication` helper parallel to `checkExternalAuthentication`.
 
 ## Proposed architecture
 
-LDAP authentication is implemented as a service behind a factory (mirroring PAM), with the user lifecycle handled at the login orchestration layer so just-in-time provisioning and role mapping are possible:
+LDAP directory operations live behind a factory (mirroring PAM). User provisioning and role mapping stay in `LoginHelper`, reusing the external-auth lifecycle:
 
 ```text
-LdapServiceFactory            (selects the configured implementation; testable seam)
+LdapServiceFactory
   -> LdapAuthenticationService
-       -> LdapConnectionProvider   (UnboundID LDAPConnectionPool, TLS, timeouts, failover)
+       -> LdapConnectionProvider   (UnboundID LDAPConnectionPool, TLS, timeouts)
        -> LdapUserResolver         (bind/search/bind, attribute extraction)
        -> LdapGroupResolver        (member= search and/or memberOf, normalization)
-  -> LdapLoginAdapter            (maps the LDAP result onto CreateUserCommand /
-                                  UpdateUserCommand / UserManager.resetTemporaryRoles)
-```
 
-Class names are indicative; the responsibilities are the design contract: connection handling, user lookup, group lookup, and mapping onto the Uyuni user lifecycle.
+LoginHelper.checkLdapAuthentication(login, password)
+  -> LdapAuthenticationService.authenticate(...)
+  -> newRemoteUser / updateRemoteUser / getRolesFromExtGroups   (shared with REMOTE_USER)
+```
 
 ```mermaid
 sequenceDiagram
     participant B as Browser/API
+    participant LC as LoginController
+    participant LH as LoginHelper
     participant UM as UserManager.loginUser
     participant LS as LdapAuthenticationService
     participant DIR as LDAP/AD server
-    participant LA as LdapLoginAdapter
     participant DB as PostgreSQL
 
-    B->>UM: login + password
-    UM->>UM: lookupByLogin(login)
-    alt local user and valid local password
-        UM->>DB: local DB password check -> success
-    else native LDAP
-        UM->>LS: authenticate(login, password)
-        LS->>DIR: service bind, search user, bind as user DN, resolve groups
-        LS-->>UM: identity + attributes + group labels
-        UM->>LA: provision/update user, map groups
-        LA->>DB: web_contact + rhnUserGroupMembers (temporary='Y')
-    else PAM
-        UM->>UM: UserImpl PAM branch
+    B->>LC: login + password
+    LC->>LH: checkExternalAuthentication()
+  Note over LH: REMOTE_USER path (unchanged)
+    alt REMOTE_USER authenticated
+        LH-->>LC: user
+    else not external
+        LC->>LC: lookupByLogin(login)
+        alt auth_type LOCAL or PAM
+            LC->>UM: loginUser(login, password)
+            UM->>DB: local DB or PAM only
+            UM-->>LC: user or failure
+        else auth_type LDAP
+            LC->>LH: checkLdapAuthentication(login, password)
+            LH->>LS: authenticate(login, password)
+            LS->>DIR: bind/search/bind, resolve groups
+            LS-->>LH: identity + attributes + groups
+            LH->>LH: updateRemoteUser + map roles
+            LH-->>LC: user
+        else lookup fails (unknown user)
+            LC->>LH: checkLdapAuthentication(login, password)
+            LH->>LS: try configured LDAP servers (priority order)
+            LS->>DIR: bind/search/bind, resolve groups
+            LS-->>LH: identity + attributes + groups
+            LH->>LH: newRemoteUser (JIT), auth_type = LDAP
+            LH-->>LC: user
+        end
     end
-    UM->>B: successfulLogin(user)
+    LC->>LH: successfulLogin(user)
+    LH-->>B: session
 ```
 
-## Login ordering
+## Login routing
 
-The credential resolution order for username/password login is **Local DB → Native LDAP → PAM**. Concretely, in `UserManager.loginUser` (after the `REMOTE_USER` external-auth check that already runs first in `LoginController`):
+Password login does **not** cascade through Local → LDAP → PAM. Each known user is routed by `auth_type` on `rhnUserInfo`:
 
-1. Look up the user by login. If a local user exists, has a usable local password, and that password verifies, log in locally.
-2. Otherwise attempt native LDAP (bind/search/bind). On success, provision or update the user, map groups to temporary roles, and log in.
-3. Otherwise attempt PAM (unchanged).
-4. Otherwise fail with a single generic message (see Failure modes).
+| `auth_type` | Backend | Notes |
+| --- | --- | --- |
+| `LOCAL` | Local DB password (`UserImpl.authenticate`, non-PAM branch) | Default for existing users without PAM |
+| `PAM` | PAM (`UserImpl.authenticate`, PAM branch) | Replaces today's `use_pam_authentication = Y` |
+| `LDAP` | `LoginHelper.checkLdapAuthentication` → `LdapAuthenticationService` | Directory bind/search/bind |
 
-This ordering is why the LDAP step lives at the orchestration layer and not inside `UserImpl.authenticate()`: step 2 may need to create a user that does not yet exist locally, while `UserImpl.authenticate()` runs only after `UserFactory.lookupByLogin()` has found one.
+Orchestration stays in `LoginController.performLogin()`:
+
+1. `LoginHelper.checkExternalAuthentication()` — `REMOTE_USER` headers (unchanged).
+2. `UserFactory.lookupByLogin(login)` — decide the path from stored `auth_type`:
+   - user exists, `auth_type = LOCAL` or `PAM` → `UserManager.loginUser(login, password)` only; **LDAP is not attempted**.
+   - user exists, `auth_type = LDAP` → `LoginHelper.checkLdapAuthentication(login, password)` only.
+   - lookup fails → `LoginHelper.checkLdapAuthentication(login, password)` probes configured LDAP servers (priority order) for JIT.
+3. `LoginHelper.successfulLogin()`.
+
+Step 2 is a dispatch, not a cascade: each login hits exactly one credential backend. `checkLdapAuthentication` mirrors the external-auth lifecycle (`newRemoteUser` / `updateRemoteUser` / `getRolesFromExtGroups`).
+
+**Known user:** lookup succeeds → read `auth_type` → dispatch to exactly one backend. Wrong password on that backend fails immediately; no fallback to another backend.
+
+**Unknown user (lookup fails):** try configured LDAP servers in administrator-defined priority order. On success, JIT-provision the user (if `provisioning_mode = JIT`) with `auth_type = LDAP`. If all servers fail, reject with a generic login error.
+
+**Migration:** existing users with `use_pam_authentication = Y` become `auth_type = PAM`; all others default to `LOCAL`. JIT-created LDAP users get `auth_type = LDAP`.
+
+This is why LDAP does not belong inside `UserImpl.authenticate()`: provisioning and group mapping require the `LoginHelper` lifecycle, and `UserManager.loginUser` assumes the user already exists.
 
 ## LDAP authentication flow
 
@@ -105,67 +146,59 @@ The provider uses the standard bind/search/bind sequence:
 2. Search for the user under the configured base DN using the configured filter; require **exactly one** match.
 3. Reject an empty supplied password outright, then bind as the discovered user DN with that password. (Many directories treat a bind with a valid DN and an empty password as a successful unauthenticated bind, so an empty password must never reach the bind call.)
 4. Resolve the user's groups.
-5. Return the normalized login, profile attributes, and group labels to the lifecycle adapter.
+5. Return the normalized login, profile attributes, and group labels to `LoginHelper`.
 
-User input is never concatenated into a filter; values are escaped (the POC uses `Filter.createEqualityFilter`, which escapes automatically). Selecting the server type pre-fills attribute and filter defaults (AD vs. IPA/POSIX), so administrators rarely type raw attribute names:
+User input is never concatenated into a filter; values are escaped (the POC uses `Filter.createEqualityFilter`, which escapes automatically). Server type pre-fills attribute and filter defaults (AD vs. IPA/POSIX):
 
 ```text
-ldap.server_type        = ACTIVE_DIRECTORY        # or FREE_IPA / OPENLDAP / POSIX
-ldap.url                = ldaps://ad.example.com:636
-ldap.bind_dn            = CN=uyuni-reader,OU=Service,DC=example,DC=com
-ldap.user_base_dn       = OU=Users,DC=example,DC=com
-ldap.user_filter        = (&(objectClass=user)(sAMAccountName={login}))
-ldap.login_attribute    = sAMAccountName           # uid for FreeIPA/OpenLDAP/POSIX
-ldap.group_base_dn      = OU=Groups,DC=example,DC=com
-ldap.group_filter       = (&(objectClass=group)(member={userDn}))
+ldap.server_type          = ACTIVE_DIRECTORY
+ldap.url                  = ldaps://ad.example.com:636
+ldap.bind_dn              = CN=uyuni-reader,OU=Service,DC=example,DC=com
+ldap.user_base_dn         = OU=Users,DC=example,DC=com
+ldap.user_filter          = (&(objectClass=user)(sAMAccountName={login}))
+ldap.login_attribute      = sAMAccountName
+ldap.group_base_dn        = OU=Groups,DC=example,DC=com
+ldap.group_filter         = (&(objectClass=group)(member={userDn}))
 ldap.group_name_attribute = cn
-ldap.provisioning_mode  = JIT                      # default; EXISTING_ONLY opt-in
-ldap.default_org_id     = 1
+ldap.provisioning_mode    = JIT
+ldap.default_org_id       = 1
 ```
 
 ## User provisioning
 
-Two modes, controlled by `provisioning_mode`:
+Two modes, controlled per LDAP server (`provisioning_mode`):
 
-- **JIT** (default): a successful LDAP login creates the Uyuni user if absent, reusing `CreateUserCommand` exactly as `LoginHelper.newRemoteUser` does today (login set, non-usable placeholder password, attributes, org, temporary roles).
-- **EXISTING_ONLY**: LDAP authenticates only users that already exist in `web_contact`.
+- **JIT** (default): a successful LDAP login creates the Uyuni user if absent, reusing `CreateUserCommand` as `LoginHelper.newRemoteUser` does today. The new user is stored with `auth_type = LDAP`.
+- **EXISTING_ONLY**: LDAP authenticates only users that already exist in `web_contact` with `auth_type = LDAP`.
 
-JIT is the default because the project goal and the Satellite/Foreman precedent both assume directory users can log in without a pre-created account, and Uyuni already implements this lifecycle for external auth. When JIT is enabled, the UI requires a valid `default_org_id`, mirroring the existing `EXTAUTH_DEFAULT_ORGID` behavior. Attribute- or group-based org mapping is a later enhancement. `EXISTING_ONLY` remains available for deployments that require manual user creation first.
-
-On each successful login, selected profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`, as `updateRemoteUser` does; missing LDAP attributes do not overwrite existing Uyuni values.
+When JIT is enabled, the UI requires a valid `default_org_id`, mirroring `EXTAUTH_DEFAULT_ORGID`. On each successful login, profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`; missing LDAP attributes do not overwrite existing Uyuni values.
 
 ## Group resolution and role mapping
 
-The portable baseline is a group-side search, which the POC confirmed works without a server-side `memberOf` overlay:
+Baseline group lookup (POC-validated on OpenLDAP):
 
 ```text
 (&(objectClass=groupOfNames)(member=<userDN>))     # OpenLDAP / generic
 (&(objectClass=group)(member=<userDN>))            # Active Directory
 ```
 
-`memberOf` on the user entry is supported as an optional optimization where the directory exposes it. Group labels are normalized to a configured attribute (default `cn`), with full-DN matching available where simple names are ambiguous. Nested groups are AD-specific (matching-rule OID `1.2.840.113556.1.4.1941`) and are deferred to a later iteration.
+`memberOf` is an optional optimization. Nested groups are deferred.
 
-Role mapping reuses the existing external group mechanism rather than introducing a new model. `rhnUserGroup` remains the role-assignment model. The `rhnUserExtGroup` / `rhnUserExtGroupMapping` tables are live, not dormant: they are already consumed by the header-based `REMOTE_USER` path (`LoginHelper.checkExternalAuthentication`) and managed through `ExtGroupDetailAction` (UI) and `UserExternalHandler` (API). A mapping row associates an external group label with one or more role *types* (`rhnUserExtGroupMapping.int_group_type_id -> rhnUserGroupType`) and is org-scoped through the existing nullable `rhnUserExtGroup.org_id`. `access.accessGroup` is the authorization layer for new endpoints, not the LDAP role target.
+Role mapping reuses `rhnUserExtGroup` / `rhnUserExtGroupMapping` (live today for `REMOTE_USER`):
 
 ```text
-LDAP groups
-  -> normalize to external group labels (cn by default)
-  -> UserGroupFactory.lookupExtGroupByLabel(label)   (rhnUserExtGroup -> rhnUserExtGroupMapping)
-  -> collect mapped role types (rhnUserGroupType), unmapped labels skipped
-  -> resolve org-scoped roles for the user's org
-  -> assign as temporary roles (CreateUserCommand/UpdateUserCommand.setTemporaryRoles)
-  -> on each login, UserManager.resetTemporaryRoles recomputes the set
+LDAP groups -> normalize labels (cn)
+  -> UserGroupFactory.lookupExtGroupByLabel(label)
+  -> mapped role types (rhnUserGroupType); unmapped labels skipped
+  -> temporary roles via CreateUserCommand / UpdateUserCommand
+  -> UserManager.resetTemporaryRoles on each login
 ```
 
-The POC reproduced this exact resolution (loop, lookup, skip-if-unmapped, union of role types) against the fixture: `uyuni-admins` mapped to Org Admin and `uyuni-users` to a system-group role, with a directory-only user provisioned just-in-time and an existing user taking the update path.
-
-Manually assigned permanent roles are never removed by LDAP login; only temporary (LDAP-derived) roles are recomputed, so a user removed from a directory group loses the corresponding Uyuni role on next login. The existing `EXTAUTH_KEEP_TEMPROLES` switch (`UserExternalHandler.setKeepTemporaryRoles`) governs whether temporary roles survive a later non-LDAP login.
-
-This also promotes the LDAP group to a first-class, managed entity: the `rhnUserExtGroup` row becomes the persisted representation of a known LDAP group, optionally scoped to a specific server (see Database design), managed from the Admin UI/API. The existing `REMOTE_USER` path is left untouched in v1. The resolution logic currently lives in `private` methods of `LoginHelper` (`getRolesFromExtGroups`, `newRemoteUser`, `updateRemoteUser`), so a prerequisite refactor extracts it into a reusable component that both the header-based path and the new LDAP adapter call, with tests covering the shared seam.
+Manually assigned permanent roles are never removed. Only temporary (LDAP-derived) roles are recomputed. The `private` methods in `LoginHelper` (`getRolesFromExtGroups`, `newRemoteUser`, `updateRemoteUser`) must be extracted into a shared component before the LDAP path can call them.
 
 ## RBAC integration
 
-The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) is used only to protect the new LDAP configuration endpoints: the setup pages and API methods are registered in the RBAC endpoint mapping[^3] so only privileged administrators can read or change LDAP configuration. LDAP-derived user roles continue to flow through `rhnUserGroup`. Automatic population of `access.accessGroup` from LDAP groups is out of scope for v1 and left as future work once the RBAC model stabilizes.
+The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) protects only the new LDAP configuration endpoints[^3]. LDAP-derived user roles continue through `rhnUserGroup`. Automatic `access.accessGroup` population from LDAP is out of scope for v1.
 
 ## Database design
 
@@ -174,92 +207,177 @@ Reused tables:
 | Table | Use |
 | --- | --- |
 | `web_contact` | user identity; JIT users get a non-usable placeholder password |
+| `rhnUserInfo` | per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`); replaces `use_pam_authentication` over time |
 | `rhnUserGroup` / `rhnUserGroupType` | org-scoped role instances (unchanged) |
 | `rhnUserGroupMembers` | role membership; `temporary='Y'` for LDAP-derived roles |
-| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role-type mapping (live; also used by header-based external auth); `rhnUserExtGroup.org_id` already scopes a mapping to an org |
-| `suseCredentials` | bind password, via a new `ldap` credential type (see below) |
+| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role-type mapping |
+| `suseCredentials` | bind password via new `ldap` credential type |
 
-One new entity (working name `suseLdapAuthServer`, one row per configured directory) holds the connection and mapping configuration. Rather than fix the exact columns, types, and constraints now, the design captures the data the entity must hold, grouped by purpose; the concrete schema is settled during implementation:
+One new entity (`suseLdapAuthServer`, one row per directory) holds connection and mapping configuration:
 
-- **Connection** - label, enabled flag, server type, host, port, transport, and a connect/response timeout. Server type (`ACTIVE_DIRECTORY` / `FREE_IPA` / `OPENLDAP` / `POSIX`) and transport (`LDAPS` / `STARTTLS` / `PLAIN`) are modeled as Java enums, as CoCo attestation models `env_type`[^6].
-- **Bind account** - a reference to the stored bind credentials (the bind DN as the credential `username` and the bind password; no credential row means anonymous bind), as described under bind-password storage below.
-- **User lookup** - user base DN, user search filter, login attribute, and optional first-name, last-name, and email attributes.
-- **Group lookup** - group base DN, group filter, group-name attribute (default `cn`), a `memberOf` toggle, and an optional pre-authentication scope filter.
-- **Provisioning** - provisioning mode (`JIT` / `EXISTING_ONLY`) and the default org applied to JIT-created users.
+- **Connection** — label, enabled, server type, host, port, transport, timeout, priority (for multi-server probe order).
+- **Bind account** — reference to `suseCredentials` (bind DN as `username`; no row = anonymous bind).
+- **User lookup** — user base DN, filter, login and profile attribute names.
+- **Group lookup** — group base DN, filter, group-name attribute, optional `memberOf` toggle.
+- **Provisioning** — mode (`JIT` / `EXISTING_ONLY`) and default org for JIT users.
 
-This entity is the single source of truth for a directory, and the enum-backed fields keep server-type and transport handling type-safe in Java rather than relying on free-form strings.
+A nullable directory FK on `rhnUserExtGroup` optionally scopes external-group mappings to one server (null = server-agnostic, as today for `REMOTE_USER`).
 
-To make external groups first-class and optionally LDAP-scoped, the design adds a nullable reference from `rhnUserExtGroup` to the new directory entity. A null value preserves today's server-agnostic behavior (used by `REMOTE_USER`); a set value scopes the mapping to one directory. Modeling this as a nullable link on the existing table, rather than a parallel new table, avoids duplicating the established external-group mechanism. Note that `rhnUserExtGroup` already carries a nullable `org_id` and a unique index on `(label, org_id)`; adding directory scoping must extend that uniqueness accordingly (for example `(label, org_id, directory_id)`), which is one reason this is flagged as an unresolved question rather than settled here.
-
-The **bind password** is stored in `suseCredentials` under a new `ldap` credential type, reusing the `PasswordBasedCredentials` pattern already used for SCC, registry, and cloud-RMT credentials (the abstract superclass Base64-encodes on `setPassword` and decodes on `getPassword`, persisting to the `password` column). In practice this adds an `LDAP` value to the `CredentialsType` enum and an `LdapCredentials` entity, plus two schema touches confirmed by reading `suseCredentials.sql`: the `rhn_type_ck` `IN (...)` list must gain `'ldap'`, and the per-type `cred_type_check` `CASE` (which today requires both `username` and `password` for every existing type) must be handled deliberately. LDAP does not fit that username+password pair cleanly: the service account is identified by a full bind DN, and anonymous bind has no credentials at all. The cleaner of two options is taken as the working assumption: store the bind DN as the credential `username` (keeping the existing pair shape, with anonymous bind meaning no credential row), rather than adding a relaxed `ldap` branch that requires only a password. The password remains write-only in the UI/API, as SCC credentials are. Whether Base64-at-rest is sufficient or stronger encryption is required is left open below.
+Bind passwords reuse the existing `PasswordBasedCredentials` / `suseCredentials` pattern as-is (bind DN stored as credential `username`, Base64-at-rest like SCC/registry credentials). A future migration to salted or encrypted credential storage is orthogonal to this feature and should not change the LDAP integration interface. Schema constraints on `suseCredentials` need a new `ldap` credential type.
 
 ## Transport security
 
-Production deployments must use encrypted transport (`LDAPS` or `STARTTLS`); `PLAIN` is allowed only for explicit dev/test. Trust material is validated against the JVM trust store. Because the server container already mounts CA anchors at `/etc/pki/trust/anchors/`, administrators can add the directory CA there or upload it through the UI. The exact integration is left open below.
+Production deployments use `LDAPS` or `STARTTLS`; `PLAIN` only for explicit dev/test. Directory CA certificates are uploaded through the LDAP setup UI/API (write-only upload, same interaction pattern as Hub peripheral CA upload in **Admin → Hub Configuration → Add Peripheral**). Uyuni does not yet provide a generic CA-storage service, so v1 implements LDAP-specific CA handling rather than reusing a shared component. Uploaded CAs are installed into the server trust store used for LDAP connections.
 
 ## Connection handling
 
-A pooled service connection (`LDAPConnectionPool`, validated in the POC) is used for searches, and a short-lived dedicated connection is used for each user credential bind. A connect/response timeout of 3–5s ensures an unreachable directory fails fast. Multiple servers can be combined via UnboundID's `FailoverServerSet` for HA in a later iteration.
+A pooled service connection (`LDAPConnectionPool`) handles searches; each user credential bind uses a short-lived connection. Connect/response timeout of 3–5s. Multiple servers are tried in priority order for unknown-user LDAP probe; HA failover via `FailoverServerSet` is a later iteration.
 
 ## Failure modes
 
 | Situation | Behavior |
 | --- | --- |
-| Active session, LDAP goes down | Unaffected; LDAP is checked only at login, never mid-session |
-| Local user logs in, LDAP down | Unaffected; local auth is first and independent |
-| LDAP user logs in, LDAP unreachable | Fail after the timeout; show "invalid credentials or directory unreachable, try again later" |
-| LDAP user, wrong password | Reject (invalid credentials) |
-| LDAP user also has a local password | No silent fallback to local after LDAP failure |
-| User search returns 0 or >1 entries | Treat as authentication failure (ambiguous) |
-| Group lookup fails after successful bind | Authenticate, assign no LDAP-derived roles, log the failure |
+| Active session, LDAP goes down | Unaffected; LDAP checked only at login |
+| `LOCAL` user, LDAP down | Unaffected; routed to local DB only |
+| `LDAP` user, LDAP unreachable | Fail after timeout; generic error message |
+| `LDAP` user, wrong password | Reject; no fallback to local or PAM |
+| Unknown user, all LDAP servers fail | Generic login failure |
+| User search returns 0 or >1 entries | Authentication failure; **log details** (filter, base DN, result count) for the administrator |
+| Group lookup fails after successful bind | Authenticate; no LDAP-derived roles; **log failure with details** |
 | User maps to no Uyuni roles | Login succeeds with no temporary roles |
+| Same login exists as `LOCAL` user | LDAP JIT blocked; `auth_type` on existing row wins |
 
-The generic failure message intentionally does not distinguish "user unknown" from "wrong password" from "server down" to avoid user enumeration; details go to the server log.
+The UI shows only a generic message ("invalid credentials" or "user unknown"). It does **not** expose whether the password was wrong, the directory was unreachable, or the search was ambiguous. Those distinctions are written to the server log with enough detail for an administrator to correct configuration (LDAP URL, bind DN, filters, attribute mappings).
 
 ## User interface and API
 
-A new **Admin -> Setup -> LDAP** area follows Satellite's proven four-tab layout: **Server** (host, port, transport, type), **Account** (bind DN/password, base DNs, filters, provisioning mode, default org), **Attribute mappings** (login/name/email/group attributes, pre-filled from server type), and **User Groups** (external group to role bindings, extending the existing `ExtGroupDetailAction` UI). Three test actions give immediate feedback before LDAP is enabled and map directly onto POC operations: test connection (service bind), test user lookup (search), and test group resolution. A freshly provisioned user with no mapped groups logs in with no permissions until a mapping matches.
+A new **Admin → Setup → LDAP** area follows the **Satellite 6 LDAP authentication source** layout[^8]. Satellite places LDAP configuration under **Administer → LDAP authentication**; Uyuni uses its own Setup path but keeps the same **three-tab** auth-source editor:
 
-Both API interfaces are provided, following the HTTP API RFC convention: the existing `user.external` XML-RPC namespace (`UserExternalHandler`) is extended for group-to-role mappings, a new `auth.ldap` namespace handles server CRUD and the test operations, and the same handlers are auto-exposed over JSON via the Spark route wrapper.
+1. **Server** (or "LDAP server") — name, host, port, TLS, directory type  
+2. **Account** — bind credentials, base DNs, optional search filter, JIT provisioning  
+3. **Attribute mappings** — login / name / email attributes, pre-filled per server type  
+
+External group → role mapping is **not** a fourth tab on the auth source in Satellite. It lives under **User Groups → External groups** (external group name + auth source → roles). Uyuni reuses the existing external-group UI (`ExtGroupDetailAction` / `UserExternalHandler`) for LDAP group → Uyuni role bindings, scoped to a directory where needed. Uyuni maps LDAP groups to role types directly via `rhnUserExtGroup`; Satellite uses an intermediate user group.
+
+On the **Users** list, Satellite shows an **Authorized by** column (`INTERNAL` vs. the LDAP source name, e.g. `LDAP-AD-AUTH`). Uyuni exposes the same idea through per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`) and, where applicable, the directory that authenticated the user.
+
+Three test actions on the LDAP server form map to POC operations: test connection, test user lookup, test group resolution.
+
+### UI mockups (basic)
+
+**Server list** (Satellite: "Authentication Source Configuration")
+
+```text
++-- Admin > Setup > LDAP -------------------------------------+
+|  LDAP-based user information and authentication.            |
+|  Requires an LDAP provider (OpenLDAP, FreeIPA, or AD).      |
+|  [+ New LDAP server]                                        |
+|  +--------------------------------------------------------+ |
+|  | Name      Host              Type   Priority  Enabled    | |
+|  | corp-ad   ad.example.com     AD    1         [x]  Edit | |
+|  +--------------------------------------------------------+ |
++-------------------------------------------------------------+
+```
+
+**Edit server — tabs:** `[ Server | Account | Attribute mappings ]`
+
+**Server tab**
+
+```text
+Name *:       [corp-ad]
+Host *:       [ad.example.com]  Port *: [636]  [x] LDAPS
+Server type *: [Active Directory v]
+[ Test connection ]
+```
+
+**Account tab**
+
+```text
+Bind DN:      [CN=reader,OU=Service,DC=example,DC=com]  (optional)
+Password:     [********]  (write-only, optional)
+User base:    [OU=Users,DC=example,DC=com]
+Group base:   [OU=Groups,DC=example,DC=com]
+LDAP filter:  [(&(objectClass=user)(sAMAccountName={login}))]  (optional)
+[x] Automatically create accounts on first login (JIT)
+    Default org for new users: [Default v]
+[x] Sync external groups on login
+[ Test user lookup ]  [ Test group resolution ]
+```
+
+**Attribute mappings tab**
+
+```text
+Login:       [sAMAccountName]     e.g. uid
+First name:  [givenName]
+Last name:   [sn]
+Email:       [mail]
+(pre-filled from server type; editable)
+```
+
+**External group mapping** (existing Setup UI, not a tab on the LDAP server — Satellite: User Groups → External groups)
+
+```text
+External group name: [uyuni-admins]   Auth source: [corp-ad v]
+  -> Uyuni role(s): [Org Admin]
+[+ Add mapping]
+```
+
+**API:** extend `user.external` (`UserExternalHandler`) for group mappings; new `auth.ldap` namespace for server CRUD and test operations; JSON via Spark route wrapper per HTTP API RFC[^7].
 
 ## Phasing
 
-1. **Backend authentication** - `LdapServiceFactory` + `LdapAuthenticationService`, bind/search/bind, Local -> LDAP -> PAM ordering, minimal config, unit + integration tests against the fixture.
-2. **Provisioning + roles** - JIT user creation, profile sync, group-to-role mapping via `rhnUserExtGroup`, temporary-role reset.
-3. **UI + API** - four-tab Admin UI, test actions, XML-RPC + JSON endpoints, RBAC registration.
-4. **Advanced** - auth-source filter, multiple servers/failover, the `memberOf` path, AD nested groups, and AD large-group range retrieval (`member;range=`).
+1. **Backend** — `LdapServiceFactory` + `LdapAuthenticationService`, bind/search/bind, fixture tests.
+2. **Login wiring** — `auth_type` on `rhnUserInfo`, `checkLdapAuthentication` in `LoginController`, extract shared `LoginHelper` lifecycle.
+3. **Provisioning + roles** — JIT creation, profile sync, group-to-role mapping, temporary-role reset.
+4. **UI + API** — three-tab LDAP server UI, external-group mapping in existing Setup UI, test actions, RBAC endpoint registration.
+5. **Advanced** — HA failover, `memberOf` path, AD nested groups, `member;range=`.
 
 ## Testing
 
-A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-users`) backs integration tests, seeded from the existing POC. Unit tests cover filter construction/escaping, attribute mapping, group normalization, role mapping, and temporary-role reset. Regression tests confirm local and PAM logins and the ordering are unaffected. The primary validation target for the v1 test matrix and documentation is still to be confirmed with maintainers (Active Directory, FreeIPA, or OpenLDAP); other directories are best-effort. Note: the core test tree currently has pre-existing compile breakage (`RhnMockHttpServletHttpServletResponse`, `SimpleTestingResponse`); whether it is fixed as part of this work is for the maintainers to decide.
+OpenLDAP fixture (`tooling/dev-ldap`, seeded `alice`/`bob`, groups `uyuni-admins`/`uyuni-users`) backs integration tests. Unit tests cover filter escaping, attribute mapping, group normalization, role mapping, and `auth_type` routing. Regression tests confirm `LOCAL`, `PAM`, and `REMOTE_USER` paths are unaffected.
+
+## Proof of concept
+
+A standalone POC (UnboundID LDAP SDK 7.0.4, Java 17, `tooling/ldap-poc`) against a seeded OpenLDAP fixture (`tooling/dev-ldap`) validated:
+
+- Service-account bind, pooled connections, user search, credential bind
+- Group resolution by `(member=<userDN>)` without a `memberOf` overlay
+- Group-label-to-role mapping mirroring `LoginHelper.getRolesFromExtGroups`
+- JIT provisioning for a directory-only user and profile/role update for an existing user
+
+Findings fed into this RFC: external-group mapping is live; mapping is at the role-*type* level; `LoginHelper` lifecycle methods are `private` and must be extracted; profile attributes need configurable fallbacks.
+
+**Scope.** OpenLDAP only, plain LDAP (no TLS), standalone simulation — not yet wired into `LoginController` or a live database. Active Directory, FreeIPA, LDAPS/StartTLS, and anonymous bind are designed from code reading and precedent, not yet executed in-product.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- It adds code to a security-sensitive path; mistakes in ordering, fallback, filter escaping, or mapping could cause auth/authz bugs.
-- It introduces a runtime dependency on an external directory; timeouts and failure modes must be disciplined.
-- It likely adds a new third-party Java dependency (UnboundID LDAP SDK) that must clear licensing/packaging review.
-- It reuses the existing external-group mapping code, whose resolution logic currently sits in `private` `LoginHelper` methods and must be extracted into a shared component (with test coverage) before the LDAP adapter can call it.
-- The role-assignment path it reuses (`CreateUserCommand` and the temporary-role mechanism) is itself mid-migration to the new RBAC model (`CreateUserCommand` already bypasses legacy roles in favor of RBAC implied roles), so the temporary-role semantics this design depends on may shift while RBAC lands.
-- LDAP/AD deployments vary widely; v1 must choose clear defaults and document its limits rather than support every schema.
+- Security-sensitive path; mistakes in routing, filter escaping, or mapping could cause auth/authz bugs. Per-user `auth_type` dispatch with no ordering and no fallback between backends (per mentor feedback) mitigates part of this risk.
+- Runtime dependency on an external directory; timeouts and failure modes must be disciplined.
+- New third-party dependency (UnboundID LDAP SDK) pending licensing review.
+- `LoginHelper` lifecycle methods are `private` and must be extracted before LDAP can reuse them.
+- Temporary-role mechanism is mid-migration to RBAC; semantics may shift.
+- LDAP/AD schema variety; v1 documents clear defaults and limits.
 
 # Alternatives
 [alternatives]: #alternatives
 
-- **Stay on PAM/SSSD only** - no new code, but no in-product configuration, testing, profile sync, or group-to-role mapping. Does not meet the goal.
-- **Improve only header-based `REMOTE_USER`** - keeps authentication outside Uyuni and still requires a proxy or IdP, with no in-product visibility. The Spacewalk/IPA integration[^4] is the precedent for this approach and its limits.
-- **LDAP only inside `UserImpl.authenticate()`** - minimal and mirrors the PAM branch, but cannot do first-login provisioning because user lookup precedes authentication; viable only for an `EXISTING_ONLY` build.
-- **Implementation-level choices** - for the LDAP client library, JNDI avoids a third-party dependency but is lower-level with harder pooling, StartTLS, and testability, while Apache Directory LDAP API and Spring LDAP are further candidates; the UnboundID SDK[^9] is the baseline pending licensing review. For bind-password storage, a plain column on `suseLdapAuthServer` or a container-level secret were considered but rejected in favor of the existing `suseCredentials` pattern for consistency with how Uyuni already stores SCC and registry secrets.
+- **Stay on PAM/SSSD only** — no in-product configuration or group mapping. Does not meet the goal.
+- **Improve only `REMOTE_USER`** — auth stays outside Uyuni; no in-product visibility[^4].
+- **LDAP only inside `UserImpl.authenticate()`** — cannot JIT-provision; rejected in favor of `LoginController` orchestration.
+- **Local → LDAP → PAM cascade** — tries multiple backends per login; rejected as neither robust nor performant.
+- **Implementation choices** — JNDI vs. UnboundID SDK[^9]; bind password in `suseCredentials` vs. plain column (latter rejected).
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-1. **Secret storage and trust material** - is Base64-at-rest (as for SCC/registry credentials) acceptable for the bind password, or is encryption required, and where should the directory CA live: the JVM trust store, the container's `/etc/pki/trust/anchors/`, or an upload-through-UI flow?
-2. **Scoping external groups to a server** - is a nullable directory FK on `rhnUserExtGroup` the right approach (extending the existing `(label, org_id)` uniqueness to include it), or should mappings stay server-agnostic and rely only on the existing `org_id` scoping?
-3. **Superuser reachability** - may an LDAP group grant the top-level admin role, or should the highest privileges remain local-only?
-4. **Org assignment for JIT users** - is a single configured default org enough for v1, or is attribute-/group-based mapping needed early?
-5. **Identity collisions** - login order is local-first, so a local user shadows an LDAP user with the same login, and an LDAP user whose login matches an existing local account cannot authenticate via LDAP. Is shadowing the intended behavior, or should collisions be rejected or namespaced?
-6. **Temporary roles under the RBAC migration** - the reused `CreateUserCommand` / temporary-role path is being migrated to the new RBAC access-group model. Should this design target the legacy temporary-role mechanism for v1 and adapt later, or align with the RBAC migration now? Input from the RBAC authors would help settle this.
+1. **LDAP server per user** — should `rhnUserInfo` also store which directory server an LDAP user belongs to (`ldap_server_id`), or probe all servers in priority order on every LDAP login?
+2. **Scoping external groups to a server** — nullable directory FK on `rhnUserExtGroup` (extending `(label, org_id)` uniqueness), or server-agnostic mappings only?
+3. **Superuser reachability** — may an LDAP group grant the top-level admin role, or remain local-only?
+4. **Org assignment for JIT users** — single default org enough for v1, or attribute/group-based mapping needed early?
+5. **Temporary roles under RBAC migration** — target legacy temporary roles for v1 and adapt later, or align with RBAC migration now?
+
+**Settled assumptions (reviewer input):** bind passwords use the existing `suseCredentials` / `PasswordBasedCredentials` storage as-is; migrating to salted credentials is a separate task. Directory CA material is uploaded through the LDAP-specific UI/API (Hub upload pattern, not a shared CA service).
 
 # References
 [references]: #references

--- a/accepted/00000-native-ldap-authentication.md
+++ b/accepted/00000-native-ldap-authentication.md
@@ -1,5 +1,5 @@
 - Feature Name: native_ldap_authentication
-- Start Date: 2026-06-04
+- Start Date: 2026-06-03
 
 # Summary
 [summary]: #summary
@@ -41,7 +41,9 @@ The design reuses two existing patterns rather than reinventing them:
 - The **PAM service/factory shape** (`PamServiceFactory` → `DefaultPamServiceFactory` → `PamServiceWrapper`) is the structural template for isolating an external credential check behind a factory.
 - The **external-auth lifecycle** in `LoginHelper` already performs just-in-time user creation (`CreateUserCommand`), profile updates (`UpdateUserCommand`), external group to role mapping (`UserGroupFactory.lookupExtGroupByLabel`), and temporary-role assignment. This is the model for the LDAP user and role lifecycle.
 
-A standalone proof of concept (UnboundID LDAP SDK 7.0.4, Java 17) was run against a seeded OpenLDAP fixture to confirm the operations the design depends on: service-account bind, pooled connections, user search, group resolution by `(member=<userDN>)` without a `memberOf` overlay, a successful credential bind, and rejection of invalid credentials.
+A standalone proof of concept (UnboundID LDAP SDK 7.0.4, Java 17) was run against a seeded OpenLDAP fixture to confirm the operations the design depends on: service-account bind, pooled connections, user search, group resolution by `(member=<userDN>)` without a `memberOf` overlay, a successful credential bind, and rejection of invalid credentials. The POC was then extended to exercise the full proposed pipeline end to end (search, credential bind, group resolution, group-label-to-role-type mapping mirroring `LoginHelper.getRolesFromExtGroups`, and the just-in-time provisioning decision) for both a new directory-only user and an existing local user. This validated three design-critical assumptions and surfaced one gap: (a) the external-group mapping path is live, not dormant; (b) mapping is at the role-*type* level with org scoping already present on `rhnUserExtGroup`; (c) the reusable lifecycle methods in `LoginHelper` are currently `private` and must be extracted; and (d) profile attributes such as `givenName` are not guaranteed on `inetOrgPerson` entries, so first-name mapping needs a fallback. A second pass confirmed the remaining reuse claims against code: the `PasswordBasedCredentials` Base64-at-rest pattern and `CredentialsType` enum, the `PamServiceFactory` interface plus default implementation and wrapper (the structural template), and `UserManager.resetTemporaryRoles` as the shared temporary-role reset used by both `CreateUserCommand` and `UpdateUserCommand`. The one schema subtlety found in that pass is the `suseCredentials` `cred_type_check` constraint, discussed under Database design.
+
+**Scope of validation.** To be precise about what this evidence does and does not cover: the POC ran against **OpenLDAP only**, over **plain LDAP** (no TLS), as a **standalone simulation** of the orchestration logic. It did not run against Active Directory or FreeIPA, did not exercise LDAPS/StartTLS or trust-store validation, did not test anonymous bind or the `memberOf` path (only group-side `member=` search), and was not wired into the real `UserManager.loginUser` flow or `CreateUserCommand` against a live database. Those paths are designed from code reading and precedent, not yet executed; the unresolved questions below call out the ones that carry risk.
 
 ## Proposed architecture
 
@@ -101,7 +103,7 @@ The provider uses the standard bind/search/bind sequence:
 
 1. Bind with the configured service account (or anonymous bind if explicitly enabled).
 2. Search for the user under the configured base DN using the configured filter; require **exactly one** match.
-3. Bind as the discovered user DN with the password supplied at login.
+3. Reject an empty supplied password outright, then bind as the discovered user DN with that password. (Many directories treat a bind with a valid DN and an empty password as a successful unauthenticated bind, so an empty password must never reach the bind call.)
 4. Resolve the user's groups.
 5. Return the normalized login, profile attributes, and group labels to the lifecycle adapter.
 
@@ -143,24 +145,27 @@ The portable baseline is a group-side search, which the POC confirmed works with
 
 `memberOf` on the user entry is supported as an optional optimization where the directory exposes it. Group labels are normalized to a configured attribute (default `cn`), with full-DN matching available where simple names are ambiguous. Nested groups are AD-specific (matching-rule OID `1.2.840.113556.1.4.1941`) and are deferred to a later iteration.
 
-Role mapping reuses the existing external group mechanism rather than introducing a new model. `rhnUserGroup` remains the role-assignment model; `rhnUserExtGroup` / `rhnUserExtGroupMapping` are dormant but reusable; `access.accessGroup` is the authorization layer for new endpoints, not the LDAP role target.
+Role mapping reuses the existing external group mechanism rather than introducing a new model. `rhnUserGroup` remains the role-assignment model. The `rhnUserExtGroup` / `rhnUserExtGroupMapping` tables are live, not dormant: they are already consumed by the header-based `REMOTE_USER` path (`LoginHelper.checkExternalAuthentication`) and managed through `ExtGroupDetailAction` (UI) and `UserExternalHandler` (API). A mapping row associates an external group label with one or more role *types* (`rhnUserExtGroupMapping.int_group_type_id -> rhnUserGroupType`) and is org-scoped through the existing nullable `rhnUserExtGroup.org_id`. `access.accessGroup` is the authorization layer for new endpoints, not the LDAP role target.
 
 ```text
 LDAP groups
-  -> normalize to external group labels
+  -> normalize to external group labels (cn by default)
   -> UserGroupFactory.lookupExtGroupByLabel(label)   (rhnUserExtGroup -> rhnUserExtGroupMapping)
-  -> resolve org-scoped rhnUserGroup rows (the roles)
+  -> collect mapped role types (rhnUserGroupType), unmapped labels skipped
+  -> resolve org-scoped roles for the user's org
   -> assign as temporary roles (CreateUserCommand/UpdateUserCommand.setTemporaryRoles)
   -> on each login, UserManager.resetTemporaryRoles recomputes the set
 ```
 
+The POC reproduced this exact resolution (loop, lookup, skip-if-unmapped, union of role types) against the fixture: `uyuni-admins` mapped to Org Admin and `uyuni-users` to a system-group role, with a directory-only user provisioned just-in-time and an existing user taking the update path.
+
 Manually assigned permanent roles are never removed by LDAP login; only temporary (LDAP-derived) roles are recomputed, so a user removed from a directory group loses the corresponding Uyuni role on next login. The existing `EXTAUTH_KEEP_TEMPROLES` switch (`UserExternalHandler.setKeepTemporaryRoles`) governs whether temporary roles survive a later non-LDAP login.
 
-This also promotes the LDAP group to a first-class, managed entity: the `rhnUserExtGroup` row becomes the persisted representation of a known LDAP group, optionally scoped to a specific server (see Database design), managed from the Admin UI/API. The existing `REMOTE_USER` path is left untouched in v1; the LDAP adapter calls the same `LoginHelper.getRolesFromExtGroups()` resolution, and integration tests cover these previously dormant paths.
+This also promotes the LDAP group to a first-class, managed entity: the `rhnUserExtGroup` row becomes the persisted representation of a known LDAP group, optionally scoped to a specific server (see Database design), managed from the Admin UI/API. The existing `REMOTE_USER` path is left untouched in v1. The resolution logic currently lives in `private` methods of `LoginHelper` (`getRolesFromExtGroups`, `newRemoteUser`, `updateRemoteUser`), so a prerequisite refactor extracts it into a reusable component that both the header-based path and the new LDAP adapter call, with tests covering the shared seam.
 
 ## RBAC integration
 
-The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) is used only to protect the new LDAP configuration endpoints: the setup pages and API methods are registered in the RBAC endpoint mapping[^3] so only privileged administrators can read or change LDAP configuration. LDAP-derived user roles continue to flow through `rhnUserGroup`. Automatic population of `access.accessGroup` from LDAP groups is out of scope for v1.
+The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) is used only to protect the new LDAP configuration endpoints: the setup pages and API methods are registered in the RBAC endpoint mapping[^3] so only privileged administrators can read or change LDAP configuration. LDAP-derived user roles continue to flow through `rhnUserGroup`. Automatic population of `access.accessGroup` from LDAP groups is out of scope for v1 and left as future work once the RBAC model stabilizes.
 
 ## Database design
 
@@ -171,22 +176,22 @@ Reused tables:
 | `web_contact` | user identity; JIT users get a non-usable placeholder password |
 | `rhnUserGroup` / `rhnUserGroupType` | org-scoped role instances (unchanged) |
 | `rhnUserGroupMembers` | role membership; `temporary='Y'` for LDAP-derived roles |
-| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role mapping (revived) |
+| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role-type mapping (live; also used by header-based external auth); `rhnUserExtGroup.org_id` already scopes a mapping to an org |
 | `suseCredentials` | bind password, via a new `ldap` credential type (see below) |
 
 One new entity (working name `suseLdapAuthServer`, one row per configured directory) holds the connection and mapping configuration. Rather than fix the exact columns, types, and constraints now, the design captures the data the entity must hold, grouped by purpose; the concrete schema is settled during implementation:
 
 - **Connection** - label, enabled flag, server type, host, port, transport, and a connect/response timeout. Server type (`ACTIVE_DIRECTORY` / `FREE_IPA` / `OPENLDAP` / `POSIX`) and transport (`LDAPS` / `STARTTLS` / `PLAIN`) are modeled as Java enums, as CoCo attestation models `env_type`[^6].
-- **Bind account** - the service-account bind DN (null meaning anonymous bind) and a reference to the stored bind password (see below).
+- **Bind account** - a reference to the stored bind credentials (the bind DN as the credential `username` and the bind password; no credential row means anonymous bind), as described under bind-password storage below.
 - **User lookup** - user base DN, user search filter, login attribute, and optional first-name, last-name, and email attributes.
 - **Group lookup** - group base DN, group filter, group-name attribute (default `cn`), a `memberOf` toggle, and an optional pre-authentication scope filter.
 - **Provisioning** - provisioning mode (`JIT` / `EXISTING_ONLY`) and the default org applied to JIT-created users.
 
 This entity is the single source of truth for a directory, and the enum-backed fields keep server-type and transport handling type-safe in Java rather than relying on free-form strings.
 
-To make external groups first-class and optionally LDAP-scoped, the design adds a nullable reference from `rhnUserExtGroup` to the new directory entity. A null value preserves today's server-agnostic behavior (used by `REMOTE_USER`); a set value scopes the mapping to one directory. Modeling this as a nullable link on the existing table, rather than a parallel new table, avoids duplicating the established external-group mechanism.
+To make external groups first-class and optionally LDAP-scoped, the design adds a nullable reference from `rhnUserExtGroup` to the new directory entity. A null value preserves today's server-agnostic behavior (used by `REMOTE_USER`); a set value scopes the mapping to one directory. Modeling this as a nullable link on the existing table, rather than a parallel new table, avoids duplicating the established external-group mechanism. Note that `rhnUserExtGroup` already carries a nullable `org_id` and a unique index on `(label, org_id)`; adding directory scoping must extend that uniqueness accordingly (for example `(label, org_id, directory_id)`), which is one reason this is flagged as an unresolved question rather than settled here.
 
-The **bind password** is stored in `suseCredentials` under a new `ldap` credential type, reusing the `PasswordBasedCredentials` pattern already used for SCC, registry, and cloud-RMT credentials (Base64-encoded at rest). In practice this adds an `ldap` type to the credential model and a corresponding credentials entity; the password is write-only in the UI/API, as SCC credentials are. Whether Base64-at-rest is sufficient or stronger encryption is required is left open below.
+The **bind password** is stored in `suseCredentials` under a new `ldap` credential type, reusing the `PasswordBasedCredentials` pattern already used for SCC, registry, and cloud-RMT credentials (the abstract superclass Base64-encodes on `setPassword` and decodes on `getPassword`, persisting to the `password` column). In practice this adds an `LDAP` value to the `CredentialsType` enum and an `LdapCredentials` entity, plus two schema touches confirmed by reading `suseCredentials.sql`: the `rhn_type_ck` `IN (...)` list must gain `'ldap'`, and the per-type `cred_type_check` `CASE` (which today requires both `username` and `password` for every existing type) must be handled deliberately. LDAP does not fit that username+password pair cleanly: the service account is identified by a full bind DN, and anonymous bind has no credentials at all. The cleaner of two options is taken as the working assumption: store the bind DN as the credential `username` (keeping the existing pair shape, with anonymous bind meaning no credential row), rather than adding a relaxed `ldap` branch that requires only a password. The password remains write-only in the UI/API, as SCC credentials are. Whether Base64-at-rest is sufficient or stronger encryption is required is left open below.
 
 ## Transport security
 
@@ -222,11 +227,11 @@ Both API interfaces are provided, following the HTTP API RFC convention: the exi
 1. **Backend authentication** - `LdapServiceFactory` + `LdapAuthenticationService`, bind/search/bind, Local -> LDAP -> PAM ordering, minimal config, unit + integration tests against the fixture.
 2. **Provisioning + roles** - JIT user creation, profile sync, group-to-role mapping via `rhnUserExtGroup`, temporary-role reset.
 3. **UI + API** - four-tab Admin UI, test actions, XML-RPC + JSON endpoints, RBAC registration.
-4. **Advanced** - auth-source filter, multiple servers/failover, `memberOf` and AD nested groups.
+4. **Advanced** - auth-source filter, multiple servers/failover, the `memberOf` path, AD nested groups, and AD large-group range retrieval (`member;range=`).
 
 ## Testing
 
-A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-users`) backs integration tests, seeded from the existing POC. Unit tests cover filter construction/escaping, attribute mapping, group normalization, role mapping, and temporary-role reset. Regression tests confirm local and PAM logins and the ordering are unaffected. Note: the core test tree currently has pre-existing compile breakage (`RhnMockHttpServletHttpServletResponse`, `SimpleTestingResponse`); whether it is fixed as part of this work is for the maintainers to decide.
+A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-users`) backs integration tests, seeded from the existing POC. Unit tests cover filter construction/escaping, attribute mapping, group normalization, role mapping, and temporary-role reset. Regression tests confirm local and PAM logins and the ordering are unaffected. The primary validation target for the v1 test matrix and documentation is still to be confirmed with maintainers (Active Directory, FreeIPA, or OpenLDAP); other directories are best-effort. Note: the core test tree currently has pre-existing compile breakage (`RhnMockHttpServletHttpServletResponse`, `SimpleTestingResponse`); whether it is fixed as part of this work is for the maintainers to decide.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -234,7 +239,8 @@ A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-us
 - It adds code to a security-sensitive path; mistakes in ordering, fallback, filter escaping, or mapping could cause auth/authz bugs.
 - It introduces a runtime dependency on an external directory; timeouts and failure modes must be disciplined.
 - It likely adds a new third-party Java dependency (UnboundID LDAP SDK) that must clear licensing/packaging review.
-- It revives dormant `rhnUserExtGroup` code that may need repair and test coverage.
+- It reuses the existing external-group mapping code, whose resolution logic currently sits in `private` `LoginHelper` methods and must be extracted into a shared component (with test coverage) before the LDAP adapter can call it.
+- The role-assignment path it reuses (`CreateUserCommand` and the temporary-role mechanism) is itself mid-migration to the new RBAC model (`CreateUserCommand` already bypasses legacy roles in favor of RBAC implied roles), so the temporary-role semantics this design depends on may shift while RBAC lands.
 - LDAP/AD deployments vary widely; v1 must choose clear defaults and document its limits rather than support every schema.
 
 # Alternatives
@@ -248,12 +254,12 @@ A local OpenLDAP fixture (seeded with `alice`/`bob` and `uyuni-admins`/`uyuni-us
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-1. **Secret and trust material** - is Base64-at-rest (as for SCC/registry credentials) acceptable for the bind password, or is encryption required, and where should the directory CA live: the JVM trust store, the container's `/etc/pki/trust/anchors/`, or an upload-through-UI flow?
-2. **Scoping external groups to a server** - is the nullable `rhnUserExtGroup.ldap_server_id` FK the right approach, or should mappings stay server-agnostic?
+1. **Secret storage and trust material** - is Base64-at-rest (as for SCC/registry credentials) acceptable for the bind password, or is encryption required, and where should the directory CA live: the JVM trust store, the container's `/etc/pki/trust/anchors/`, or an upload-through-UI flow?
+2. **Scoping external groups to a server** - is a nullable directory FK on `rhnUserExtGroup` the right approach (extending the existing `(label, org_id)` uniqueness to include it), or should mappings stay server-agnostic and rely only on the existing `org_id` scoping?
 3. **Superuser reachability** - may an LDAP group grant the top-level admin role, or should the highest privileges remain local-only?
 4. **Org assignment for JIT users** - is a single configured default org enough for v1, or is attribute-/group-based mapping needed early?
-5. **`access.accessGroup` future** - should the RFC commit to a later phase mapping LDAP groups into the new RBAC access groups, or leave it out of scope?
-6. **Primary target directory** - which directory is the primary path for the test matrix and docs: Active Directory, FreeIPA, or OpenLDAP?
+5. **Identity collisions** - login order is local-first, so a local user shadows an LDAP user with the same login, and an LDAP user whose login matches an existing local account cannot authenticate via LDAP. Is shadowing the intended behavior, or should collisions be rejected or namespaced?
+6. **Temporary roles under the RBAC migration** - the reused `CreateUserCommand` / temporary-role path is being migrated to the new RBAC access-group model. Should this design target the legacy temporary-role mechanism for v1 and adapt later, or align with the RBAC migration now? Input from the RBAC authors would help settle this.
 
 # References
 [references]: #references

--- a/accepted/00000-native-ldap-authentication.md
+++ b/accepted/00000-native-ldap-authentication.md
@@ -12,9 +12,9 @@ Add a native, Java-based LDAP/Active Directory authentication provider to Uyuni'
 - **Unchanged** — local DB users, per-user PAM users, and header-based `REMOTE_USER` auth.
 - **Login orchestration** — `LoginController` → `LoginHelper` (same layer as `checkExternalAuthentication`), not inside `UserManager.loginUser`.
 - **Per-user routing** — `auth_type` on `rhnUserInfo` (`LOCAL` / `PAM` / `LDAP`); no cascade between backends for known users.
-- **JIT** — unknown logins probe configured LDAP servers (priority order); on success, create the user with `auth_type = LDAP`.
-- **Role mapping** — LDAP groups map to RBAC access groups by default; `org_admin`/`satellite_admin` stay on legacy roles until they migrate.
-- **Out of scope for v1** — nested AD groups, multi-server HA failover, migrating `org_admin`/`satellite_admin` to RBAC, and a generic CA-storage service.
+- **JIT** — on the Web UI / HTTP API path only: unknown logins probe configured LDAP servers (priority order); on success, create the user with `auth_type = LDAP`. XML-RPC authenticates already-provisioned LDAP users only (no JIT in v1).
+- **Role mapping** — only LDAP groups with a fixed `uyuni_` prefix are considered; the prefix is stripped before lookup. Groups map to RBAC access groups by default; `org_admin`/`satellite_admin` stay on legacy roles until they migrate (and are not configurable via LDAP until mentors confirm).
+- **Out of scope for v1** — nested AD groups, multi-server HA failover, configurable group prefix, LDAP-driven organization assignment, migrating `org_admin`/`satellite_admin` to RBAC, and a generic CA-storage service.
 
 # Motivation
 [motivation]: #motivation
@@ -26,7 +26,7 @@ Today Uyuni can authenticate against a directory only indirectly:
 
 In both cases the directory integration is invisible to Uyuni: an administrator cannot configure, test, or troubleshoot it from the product, and there is no managed concept of an "LDAP group" inside Uyuni. The external group string is consumed transiently during a `REMOTE_USER` login and then discarded.
 
-This feature brings directory integration into Uyuni so that an administrator can point Uyuni at an Active Directory, FreeIPA, or OpenLDAP server, optionally enable just-in-time user creation, map a directory group such as `uyuni-admins` to the Org Admin role, and have those users log in with the right roles without touching `sssd.conf`. Local Uyuni users continue to work unchanged.
+This feature brings directory integration into Uyuni so that an administrator can point Uyuni at an Active Directory, FreeIPA, or OpenLDAP server, optionally enable just-in-time user creation, map a directory group such as `uyuni_admins` to a Uyuni access group, and have those users log in with the right roles without touching `sssd.conf`. Local Uyuni users continue to work unchanged.
 
 # Detailed design
 [design]: #detailed-design
@@ -146,9 +146,9 @@ Uyuni has two credential-checking entry points, and LDAP must be reachable from 
 
 Because credential verification lives in the standalone `LdapAuthenticationService`, both paths call the same service. `UserManager.loginUser(login, password)` becomes `auth_type`-aware: for an `auth_type = LDAP` user it verifies the password through `LdapAuthenticationService` instead of the local/PAM `UserImpl.authenticate` branch, so an already-provisioned LDAP user can authenticate over XML-RPC.
 
-The **provisioning and group-to-role lifecycle stays in the `LoginHelper` path** (it needs the request-scoped external-group context). A first-time LDAP user who has never logged in interactively therefore does not yet exist in `web_contact`; JIT provisioning happens on their first Web UI/HTTP API login, after which the XML-RPC path works normally. (Whether JIT should also be driven from the XML-RPC path in v1 is an open question for review.)
+**v1 decision (reviewer input):** JIT provisioning and group-to-role sync run on the Web UI / HTTP API path only. XML-RPC **only authenticates** users that already exist with `auth_type = LDAP`. A first-time LDAP user must log in once via the Web UI (or be created by an admin); after that, XML-RPC works normally. Unifying the full lifecycle onto the XML-RPC path is deferred.
 
-This refines the earlier position: the LDAP **credential check** is shared by `UserManager.loginUser` (so `UserImpl.authenticate` delegates to it for LDAP users), while **provisioning and mapping** remain in the `LoginHelper` lifecycle, which `UserManager.loginUser` does not run.
+This keeps the LDAP **credential check** shared via `UserManager.loginUser` (so `UserImpl.authenticate` delegates to it for LDAP users), while **provisioning and mapping** remain in the `LoginHelper` lifecycle.
 
 ## LDAP authentication flow
 
@@ -183,7 +183,7 @@ Two modes, controlled per LDAP server (`provisioning_mode`):
 - **JIT** (default): a successful LDAP login creates the Uyuni user if absent, reusing `CreateUserCommand` as `LoginHelper.newRemoteUser` does today. The new user is stored with `auth_type = LDAP`.
 - **EXISTING_ONLY**: LDAP authenticates only users that already exist in `web_contact` with `auth_type = LDAP`.
 
-When JIT is enabled, the UI requires a valid `default_org_id`, mirroring `EXTAUTH_DEFAULT_ORGID`. On each successful login, profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`; missing LDAP attributes do not overwrite existing Uyuni values.
+When JIT is enabled, the UI requires a valid `default_org_id`, mirroring `EXTAUTH_DEFAULT_ORGID`. Organization is assigned **only at user creation** from that default org and is **never refreshed from LDAP afterward** (changing org later is unsafe because much of Uyuni's access model depends on it). On each successful login, profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`; missing LDAP attributes do not overwrite existing Uyuni values. Mapping organization from an LDAP group/attribute (e.g. `uyuni_org_`) with `default_org_id` as fallback is **Future work**.
 
 `CreateUserCommand` today automatically joins every new user to the `regular_user` RBAC access group (`user.addToGroup(AccessGroupFactory.REGULAR_USER)`). A per-server `auto_join_regular_user` option (default **on**, preserving current behavior) lets an administrator turn this off for LDAP-provisioned users, so that access is driven entirely by LDAP group-to-access-group mapping.
 
@@ -198,17 +198,20 @@ Baseline group lookup (POC-validated on OpenLDAP):
 
 `memberOf` is an optional optimization. Nested groups are deferred.
 
+**Group prefix (reviewer input):** for v1, only LDAP groups whose `cn` starts with the fixed prefix `uyuni_` are considered for role mapping. The prefix is **not configurable**. Before lookup, the prefix is stripped (e.g. directory group `uyuni_admins` maps to external-group label `admins`). All other directory groups are ignored.
+
 Role mapping reuses the `rhnUserExtGroup` / `rhnUserExtGroupMapping` machinery (live today for `REMOTE_USER`), but the mapping **target is dual**, reflecting the in-progress RBAC migration (reviewer input):
 
 - **RBAC access groups (default target).** Most roles have already migrated to RBAC access groups — `channel_admin`, `config_admin`, `system_group_admin`, `activation_key_admin`, `image_admin`, and `regular_user` (all present in `AccessGroupFactory`). LDAP groups map to these via `user.addToGroup(AccessGroup)` / `removeFromGroup`.
-- **Legacy roles (`rhnUserGroupType`).** `org_admin` and `satellite_admin` are **not** yet migrated (absent from `AccessGroupFactory`, still in `RoleFactory`) because of special backend handling. LDAP groups that grant these two administrative roles continue to map through the legacy `rhnUserGroup` / temporary-role mechanism.
+- **Legacy roles (`rhnUserGroupType`).** `org_admin` and `satellite_admin` are **not** yet migrated (absent from `AccessGroupFactory`, still in `RoleFactory`) because of special backend handling. For a first implementation, assignment of these special roles is expected to stay **Uyuni-side only** pending confirmation from tagged mentors; they are not a primary LDAP mapping target for v1.
 
 ```text
-LDAP groups -> normalize labels (cn)
+LDAP groups -> keep only labels with prefix uyuni_
+  -> strip prefix -> normalize label
   -> lookup ext-group mapping (label [, ldap_server_id])
   -> target: RBAC access group  (channel_admin, config_admin, system_group_admin,
              activation_key_admin, image_admin, regular_user)
-     or legacy role (org_admin, satellite_admin only); unmapped labels skipped
+     ; unmapped labels skipped
   -> apply on each login, recomputing only LDAP-derived memberships
 ```
 
@@ -234,13 +237,14 @@ Reused tables:
 | `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role/access-group mapping |
 | `suseCredentials` | bind password via new `ldap` credential type |
 
-One new entity (`suseLdapAuthServer`, one row per directory) holds connection and mapping configuration:
+One new entity (`suseLdapAuthServer`, one row per directory) holds connection and mapping configuration as **separate columns** (not a single blob field). Indicative columns:
 
-- **Connection** — label, enabled, server type, host, port, transport, timeout, priority (for multi-server probe order).
-- **Bind account** — bind DN stored **on `suseLdapAuthServer`** (its own column); password referenced from `suseCredentials` (no bind DN + no credential = anonymous bind).
-- **User lookup** — user base DN, filter, login and profile attribute names.
-- **Group lookup** — group base DN, filter, group-name attribute, optional `memberOf` toggle.
-- **Provisioning** — mode (`JIT` / `EXISTING_ONLY`), default org for JIT users, and `auto_join_regular_user` toggle.
+- **Connection** — `label`, `enabled`, `server_type`, `host`, `port`, `transport`, `timeout`, `priority` (for multi-server probe order).
+- **Bind account** — `bind_dn` on `suseLdapAuthServer`; password referenced from `suseCredentials` (no bind DN + no credential = anonymous bind).
+- **User lookup** — `user_base_dn`, `user_filter`, `login_attribute`, and profile attribute names (`first_name_attribute`, `last_name_attribute`, `email_attribute`) as separate fields.
+- **Group lookup** — `group_base_dn`, `group_filter`, `group_name_attribute`, optional `use_memberof` toggle as separate fields.
+- **Provisioning** — `provisioning_mode` (`JIT` / `EXISTING_ONLY`), `default_org_id` for JIT users, and `auto_join_regular_user` toggle.
+- **Trust material** — optional public CA certificate for LDAPS/STARTTLS, stored on the LDAP connection row (see Transport security).
 
 A nullable directory FK on `rhnUserExtGroup` optionally scopes external-group mappings to one server (null = server-agnostic, as today for `REMOTE_USER`).
 
@@ -248,7 +252,9 @@ Bind passwords reuse the existing `PasswordBasedCredentials` / `suseCredentials`
 
 ## Transport security
 
-Production deployments use `LDAPS` or `STARTTLS`; `PLAIN` only for explicit dev/test. Directory CA certificates are uploaded through the LDAP setup UI/API (write-only upload, same interaction pattern as Hub peripheral CA upload in **Admin → Hub Configuration → Add Peripheral**). Uyuni does not yet provide a generic CA-storage service, so v1 implements LDAP-specific CA handling rather than reusing a shared component. Uploaded CAs are installed into the server trust store used for LDAP connections.
+Production deployments use `LDAPS` or `STARTTLS`; `PLAIN` only for explicit dev/test. Directory CA certificates are uploaded through the LDAP setup UI/API (write-only upload, same interaction pattern as Hub peripheral CA upload in **Admin → Hub Configuration → Add Peripheral**).
+
+**v1 decision (reviewer input):** the public CA is **collected and stored in the Uyuni database** on the LDAP connection table (`suseLdapAuthServer`). How the Java LDAP client loads that CA into an SSL context for LDAPS/STARTTLS is an **implementation detail** (the RFC does not require writing the JVM system `cacerts`, and admins should not edit trust stores by hand). Uyuni does not yet provide a generic CA-storage service, so v1 keeps this LDAP-specific rather than a shared component.
 
 ## Connection handling
 
@@ -266,7 +272,7 @@ A pooled service connection (`LDAPConnectionPool`) handles searches; each user c
 | User search returns 0 or >1 entries | Authentication failure; **log details** (filter, base DN, result count) for the administrator |
 | Group lookup fails after successful bind | Authenticate; no LDAP-derived roles; **log failure with details** |
 | User maps to no Uyuni roles | Login succeeds with no LDAP-derived roles |
-| Same login exists as `LOCAL` user | LDAP JIT blocked; `auth_type` on existing row wins |
+| Same login already exists (any `auth_type`) | LDAP JIT blocked; existing row wins — no conflicting users |
 
 The UI shows only a generic message ("invalid credentials" or "user unknown"). It does **not** expose whether the password was wrong, the directory was unreachable, or the search was ambiguous. Those distinctions are written to the server log with enough detail for an administrator to correct configuration (LDAP URL, bind DN, filters, attribute mappings).
 
@@ -392,18 +398,32 @@ Findings fed into this RFC: external-group mapping is live; mapping is at the ro
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-1. **Marking LDAP-derived RBAC access-group membership** — RBAC access-group membership has no temporary/externally-managed flag today, unlike legacy roles (`temporary='Y'` on `rhnUserGroupMembers`). To recompute LDAP-derived access groups on each login without removing manual grants, do we (a) add a temporary/externally-managed flag to access-group membership, or (b) track LDAP-derived memberships via the ext-group mapping origin and reconcile from that? (Raised by reviewer; RBAC-owner decision.)
-2. **JIT over the XML-RPC path** — an LDAP user who has only ever used the XML-RPC API is not yet provisioned (provisioning runs in the `LoginHelper` lifecycle). Is "must log in once via Web UI/HTTP API to be provisioned" acceptable for v1, or should JIT also run from `UserManager.loginUser`?
-3. **Superuser reachability** — may an LDAP group grant `satellite_admin` (top-level admin), or remain local-only?
-4. **Org assignment for JIT users** — single default org enough for v1, or attribute/group-based mapping needed early?
+1. **Marking LDAP-derived RBAC access-group membership** — RBAC access-group membership has no temporary/externally-managed flag today, unlike legacy roles (`temporary='Y'` on `rhnUserGroupMembers`). To recompute LDAP-derived access groups on each login without removing manual grants, do we (a) add a temporary/externally-managed flag to access-group membership, (b) track LDAP-derived memberships via the ext-group mapping origin and reconcile from that, or (c) use a mode where groups are either fully local-managed or fully LDAP-managed (no merge)? (Raised by reviewer; RBAC-owner decision.)
+2. **Superuser reachability** — may an LDAP group grant `org_admin` / `satellite_admin`, or remain local-only for v1? (Reviewer preference: local-only; waiting on tagged mentors.)
+3. **Same username on multiple LDAP servers** — if more than one configured server can authenticate the same login, should the first successful login own the Uyuni account (later servers fail), bind permanently to the first matching server by priority, or reject when more than one server matches?
+4. **Kerberos / SSO for Active Directory** — AD environments often use Kerberos. Should Kerberos/SSO be in scope for this feature, or remain out of scope for v1 (password bind only)?
 
 **Settled assumptions (reviewer input):**
 - **LDAP server per user** — `rhnUserInfo` stores `ldap_server_id` (which directory authenticated/provisioned the user). *Confirmed by mentor.*
 - **Bind DN storage** — bind DN lives on `suseLdapAuthServer` (not `suseCredentials.username`, which is `VARCHAR(64)` and too short); `suseCredentials` holds only the password, using a new `ldap` credential type. Migrating to salted credentials is a separate task.
-- **Group mapping target** — LDAP groups map to RBAC access groups by default; only `org_admin`/`satellite_admin` use legacy `rhnUserGroupType` until they migrate.
+- **Group mapping target** — LDAP groups map to RBAC access groups by default; only `org_admin`/`satellite_admin` use legacy `rhnUserGroupType` until they migrate (assignment of those special roles via LDAP pending mentor confirmation).
+- **Group prefix** — fixed `uyuni_` for v1; not configurable; strip before ext-group lookup.
+- **JIT vs XML-RPC** — v1: JIT on Web UI / HTTP API only; XML-RPC authenticates already-provisioned LDAP users only.
+- **Org assignment** — v1 uses `default_org_id` only; org is set at create time and never refreshed from LDAP. LDAP-driven org is Future work.
 - **`regular_user` auto-join** — overridable per LDAP server via `auto_join_regular_user`.
-- **Directory CA material** — uploaded through the LDAP-specific UI/API (Hub upload pattern, not a shared CA service).
+- **Directory CA material** — uploaded through the LDAP-specific UI/API; public CA stored in the Uyuni DB on the LDAP connection table; how Java uses it is an implementation detail.
+- **User/group lookup storage** — separate columns on `suseLdapAuthServer`, not one blob field.
+- **JIT conflicts** — block JIT if the login already exists under any `auth_type`.
 - **Scoping external groups to a server** — nullable directory FK on `rhnUserExtGroup` (extends `(label, org_id)` uniqueness), enabling per-server mappings while keeping server-agnostic ones.
+
+# Future work
+[future-work]: #future-work
+
+- LDAP-driven organization assignment (e.g. `uyuni_org_` group or attribute) with `default_org_id` as fallback; still never change org after the user is created.
+- Configurable group prefix (beyond fixed `uyuni_`).
+- Full login-lifecycle unification on the XML-RPC path (JIT + group sync without a prior Web UI login).
+- Kerberos / SSO for Active Directory (if confirmed in scope later).
+- Nested AD groups, `memberOf` as primary path, HA failover via `FailoverServerSet`.
 
 # References
 [references]: #references

--- a/accepted/00000-native-ldap-authentication.md
+++ b/accepted/00000-native-ldap-authentication.md
@@ -13,7 +13,8 @@ Add a native, Java-based LDAP/Active Directory authentication provider to Uyuni'
 - **Login orchestration** — `LoginController` → `LoginHelper` (same layer as `checkExternalAuthentication`), not inside `UserManager.loginUser`.
 - **Per-user routing** — `auth_type` on `rhnUserInfo` (`LOCAL` / `PAM` / `LDAP`); no cascade between backends for known users.
 - **JIT** — unknown logins probe configured LDAP servers (priority order); on success, create the user with `auth_type = LDAP`.
-- **Out of scope for v1** — nested AD groups, `access.accessGroup` population from LDAP, multi-server HA failover.
+- **Role mapping** — LDAP groups map to RBAC access groups by default; `org_admin`/`satellite_admin` stay on legacy roles until they migrate.
+- **Out of scope for v1** — nested AD groups, multi-server HA failover, migrating `org_admin`/`satellite_admin` to RBAC, and a generic CA-storage service.
 
 # Motivation
 [motivation]: #motivation
@@ -136,7 +137,18 @@ Step 2 is a dispatch, not a cascade: each login hits exactly one credential back
 
 **Migration:** existing users with `use_pam_authentication = Y` become `auth_type = PAM`; all others default to `LOCAL`. JIT-created LDAP users get `auth_type = LDAP`.
 
-This is why LDAP does not belong inside `UserImpl.authenticate()`: provisioning and group mapping require the `LoginHelper` lifecycle, and `UserManager.loginUser` assumes the user already exists.
+### Two authentication entry points (Web UI/HTTP API vs. XML-RPC)
+
+Uyuni has two credential-checking entry points, and LDAP must be reachable from both:
+
+- **Interactive path** — `LoginController.performLogin()` → `LoginHelper`. Runs the full lifecycle: credential check, JIT provisioning, profile sync, and group-to-role mapping.
+- **Programmatic path** — `auth.login` (`AuthHandler`) → `UserManager.loginReadOnlyUser` → `UserManager.loginUser(login, password)` → `UserImpl.authenticate(password)`. This path does **not** pass through `LoginController`/`LoginHelper`; it is what `spacecmd` and XML-RPC API clients use.
+
+Because credential verification lives in the standalone `LdapAuthenticationService`, both paths call the same service. `UserManager.loginUser(login, password)` becomes `auth_type`-aware: for an `auth_type = LDAP` user it verifies the password through `LdapAuthenticationService` instead of the local/PAM `UserImpl.authenticate` branch, so an already-provisioned LDAP user can authenticate over XML-RPC.
+
+The **provisioning and group-to-role lifecycle stays in the `LoginHelper` path** (it needs the request-scoped external-group context). A first-time LDAP user who has never logged in interactively therefore does not yet exist in `web_contact`; JIT provisioning happens on their first Web UI/HTTP API login, after which the XML-RPC path works normally. (Whether JIT should also be driven from the XML-RPC path in v1 is an open question for review.)
+
+This refines the earlier position: the LDAP **credential check** is shared by `UserManager.loginUser` (so `UserImpl.authenticate` delegates to it for LDAP users), while **provisioning and mapping** remain in the `LoginHelper` lifecycle, which `UserManager.loginUser` does not run.
 
 ## LDAP authentication flow
 
@@ -173,6 +185,8 @@ Two modes, controlled per LDAP server (`provisioning_mode`):
 
 When JIT is enabled, the UI requires a valid `default_org_id`, mirroring `EXTAUTH_DEFAULT_ORGID`. On each successful login, profile fields (first name, last name, email) are refreshed from LDAP via `UpdateUserCommand`; missing LDAP attributes do not overwrite existing Uyuni values.
 
+`CreateUserCommand` today automatically joins every new user to the `regular_user` RBAC access group (`user.addToGroup(AccessGroupFactory.REGULAR_USER)`). A per-server `auto_join_regular_user` option (default **on**, preserving current behavior) lets an administrator turn this off for LDAP-provisioned users, so that access is driven entirely by LDAP group-to-access-group mapping.
+
 ## Group resolution and role mapping
 
 Baseline group lookup (POC-validated on OpenLDAP):
@@ -184,21 +198,27 @@ Baseline group lookup (POC-validated on OpenLDAP):
 
 `memberOf` is an optional optimization. Nested groups are deferred.
 
-Role mapping reuses `rhnUserExtGroup` / `rhnUserExtGroupMapping` (live today for `REMOTE_USER`):
+Role mapping reuses the `rhnUserExtGroup` / `rhnUserExtGroupMapping` machinery (live today for `REMOTE_USER`), but the mapping **target is dual**, reflecting the in-progress RBAC migration (reviewer input):
+
+- **RBAC access groups (default target).** Most roles have already migrated to RBAC access groups — `channel_admin`, `config_admin`, `system_group_admin`, `activation_key_admin`, `image_admin`, and `regular_user` (all present in `AccessGroupFactory`). LDAP groups map to these via `user.addToGroup(AccessGroup)` / `removeFromGroup`.
+- **Legacy roles (`rhnUserGroupType`).** `org_admin` and `satellite_admin` are **not** yet migrated (absent from `AccessGroupFactory`, still in `RoleFactory`) because of special backend handling. LDAP groups that grant these two administrative roles continue to map through the legacy `rhnUserGroup` / temporary-role mechanism.
 
 ```text
 LDAP groups -> normalize labels (cn)
-  -> UserGroupFactory.lookupExtGroupByLabel(label)
-  -> mapped role types (rhnUserGroupType); unmapped labels skipped
-  -> temporary roles via CreateUserCommand / UpdateUserCommand
-  -> UserManager.resetTemporaryRoles on each login
+  -> lookup ext-group mapping (label [, ldap_server_id])
+  -> target: RBAC access group  (channel_admin, config_admin, system_group_admin,
+             activation_key_admin, image_admin, regular_user)
+     or legacy role (org_admin, satellite_admin only); unmapped labels skipped
+  -> apply on each login, recomputing only LDAP-derived memberships
 ```
 
-Manually assigned permanent roles are never removed. Only temporary (LDAP-derived) roles are recomputed. The `private` methods in `LoginHelper` (`getRolesFromExtGroups`, `newRemoteUser`, `updateRemoteUser`) must be extracted into a shared component before the LDAP path can call them.
+Manually assigned memberships/roles are never removed; only LDAP-derived assignments are recomputed each login. The `private` methods in `LoginHelper` (`getRolesFromExtGroups`, `newRemoteUser`, `updateRemoteUser`) must be extracted into a shared component before the LDAP path (and the XML-RPC-facing credential path) can reuse them.
 
 ## RBAC integration
 
-The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) protects only the new LDAP configuration endpoints[^3]. LDAP-derived user roles continue through `rhnUserGroup`. Automatic `access.accessGroup` population from LDAP is out of scope for v1.
+The new RBAC model (`access.namespace`, `access.endpoint`, `access.accessGroup`) protects the new LDAP configuration endpoints[^3]. Beyond that, LDAP group mapping targets **RBAC access groups from the start** (not legacy-only), so the feature aligns with the migration rather than adding new legacy-only dependencies. The two unmigrated administrative roles (`org_admin`, `satellite_admin`) remain mapped through `rhnUserGroup` until they too move to RBAC.
+
+**Open design point (temporary vs. externally-managed membership).** The legacy recompute-on-login model relies on the `temporary='Y'` flag on `rhnUserGroupMembers` to distinguish auto-assigned (directory-derived) roles from manually-assigned permanent ones. RBAC access-group membership currently has **no equivalent temporary/externally-managed flag** (`User.addToGroup/removeFromGroup` are permanent add/remove only). Aligning with RBAC therefore requires deciding how LDAP-derived access-group memberships are marked so they can be recomputed without clobbering manual grants — see Unresolved questions.
 
 ## Database design
 
@@ -207,23 +227,24 @@ Reused tables:
 | Table | Use |
 | --- | --- |
 | `web_contact` | user identity; JIT users get a non-usable placeholder password |
-| `rhnUserInfo` | per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`); replaces `use_pam_authentication` over time |
-| `rhnUserGroup` / `rhnUserGroupType` | org-scoped role instances (unchanged) |
-| `rhnUserGroupMembers` | role membership; `temporary='Y'` for LDAP-derived roles |
-| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role-type mapping |
+| `rhnUserInfo` | per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`), replacing `use_pam_authentication` over time; plus `ldap_server_id` recording which directory authenticated/provisioned the user (reviewer-approved) |
+| `rhnUserGroup` / `rhnUserGroupType` | legacy org-scoped role instances (unchanged) |
+| `rhnUserGroupMembers` | legacy role membership; `temporary='Y'` for LDAP-derived `org_admin`/`satellite_admin` |
+| RBAC access groups (`access.accessGroup` + membership) | default target for LDAP-derived roles; membership recompute is the open design point above |
+| `rhnUserExtGroup` / `rhnUserExtGroupMapping` | external group to role/access-group mapping |
 | `suseCredentials` | bind password via new `ldap` credential type |
 
 One new entity (`suseLdapAuthServer`, one row per directory) holds connection and mapping configuration:
 
 - **Connection** — label, enabled, server type, host, port, transport, timeout, priority (for multi-server probe order).
-- **Bind account** — reference to `suseCredentials` (bind DN as `username`; no row = anonymous bind).
+- **Bind account** — bind DN stored **on `suseLdapAuthServer`** (its own column); password referenced from `suseCredentials` (no bind DN + no credential = anonymous bind).
 - **User lookup** — user base DN, filter, login and profile attribute names.
 - **Group lookup** — group base DN, filter, group-name attribute, optional `memberOf` toggle.
-- **Provisioning** — mode (`JIT` / `EXISTING_ONLY`) and default org for JIT users.
+- **Provisioning** — mode (`JIT` / `EXISTING_ONLY`), default org for JIT users, and `auto_join_regular_user` toggle.
 
 A nullable directory FK on `rhnUserExtGroup` optionally scopes external-group mappings to one server (null = server-agnostic, as today for `REMOTE_USER`).
 
-Bind passwords reuse the existing `PasswordBasedCredentials` / `suseCredentials` pattern as-is (bind DN stored as credential `username`, Base64-at-rest like SCC/registry credentials). A future migration to salted or encrypted credential storage is orthogonal to this feature and should not change the LDAP integration interface. Schema constraints on `suseCredentials` need a new `ldap` credential type.
+Bind passwords reuse the existing `PasswordBasedCredentials` / `suseCredentials` pattern (Base64-at-rest like SCC/registry credentials), needing a new `ldap` credential type. The **bind DN is not stored in `suseCredentials.username`** because that column is `VARCHAR(64)` (verified) and cannot hold long directory DNs; the DN lives on `suseLdapAuthServer` instead (reviewer input), leaving `suseCredentials` to hold only the secret. A future migration to salted or encrypted credential storage is orthogonal to this feature and should not change the LDAP integration interface.
 
 ## Transport security
 
@@ -244,7 +265,7 @@ A pooled service connection (`LDAPConnectionPool`) handles searches; each user c
 | Unknown user, all LDAP servers fail | Generic login failure |
 | User search returns 0 or >1 entries | Authentication failure; **log details** (filter, base DN, result count) for the administrator |
 | Group lookup fails after successful bind | Authenticate; no LDAP-derived roles; **log failure with details** |
-| User maps to no Uyuni roles | Login succeeds with no temporary roles |
+| User maps to no Uyuni roles | Login succeeds with no LDAP-derived roles |
 | Same login exists as `LOCAL` user | LDAP JIT blocked; `auth_type` on existing row wins |
 
 The UI shows only a generic message ("invalid credentials" or "user unknown"). It does **not** expose whether the password was wrong, the directory was unreachable, or the search was ambiguous. Those distinctions are written to the server log with enough detail for an administrator to correct configuration (LDAP URL, bind DN, filters, attribute mappings).
@@ -257,7 +278,7 @@ A new **Admin → Setup → LDAP** area follows the **Satellite 6 LDAP authentic
 2. **Account** — bind credentials, base DNs, optional search filter, JIT provisioning  
 3. **Attribute mappings** — login / name / email attributes, pre-filled per server type  
 
-External group → role mapping is **not** a fourth tab on the auth source in Satellite. It lives under **User Groups → External groups** (external group name + auth source → roles). Uyuni reuses the existing external-group UI (`ExtGroupDetailAction` / `UserExternalHandler`) for LDAP group → Uyuni role bindings, scoped to a directory where needed. Uyuni maps LDAP groups to role types directly via `rhnUserExtGroup`; Satellite uses an intermediate user group.
+External group → role mapping is **not** a fourth tab on the auth source in Satellite. It lives under **User Groups → External groups** (external group name + auth source → roles). Uyuni reuses the existing external-group UI (`ExtGroupDetailAction` / `UserExternalHandler`) for LDAP group → Uyuni role/access-group bindings, scoped to a directory where needed. Uyuni maps LDAP groups directly via `rhnUserExtGroup` (to RBAC access groups, or to legacy `org_admin`/`satellite_admin`); Satellite uses an intermediate user group.
 
 On the **Users** list, Satellite shows an **Authorized by** column (`INTERNAL` vs. the LDAP source name, e.g. `LDAP-AD-AUTH`). Uyuni exposes the same idea through per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`) and, where applicable, the directory that authenticated the user.
 
@@ -328,7 +349,7 @@ External group name: [uyuni-admins]   Auth source: [corp-ad v]
 
 1. **Backend** — `LdapServiceFactory` + `LdapAuthenticationService`, bind/search/bind, fixture tests.
 2. **Login wiring** — `auth_type` on `rhnUserInfo`, `checkLdapAuthentication` in `LoginController`, extract shared `LoginHelper` lifecycle.
-3. **Provisioning + roles** — JIT creation, profile sync, group-to-role mapping, temporary-role reset.
+3. **Provisioning + roles** — JIT creation, profile sync, group-to-role mapping (RBAC access groups + legacy admin roles), recompute LDAP-derived memberships on login.
 4. **UI + API** — three-tab LDAP server UI, external-group mapping in existing Setup UI, test actions, RBAC endpoint registration.
 5. **Advanced** — HA failover, `memberOf` path, AD nested groups, `member;range=`.
 
@@ -355,8 +376,8 @@ Findings fed into this RFC: external-group mapping is live; mapping is at the ro
 - Security-sensitive path; mistakes in routing, filter escaping, or mapping could cause auth/authz bugs. Per-user `auth_type` dispatch with no ordering and no fallback between backends (per mentor feedback) mitigates part of this risk.
 - Runtime dependency on an external directory; timeouts and failure modes must be disciplined.
 - New third-party dependency (UnboundID LDAP SDK) pending licensing review.
-- `LoginHelper` lifecycle methods are `private` and must be extracted before LDAP can reuse them.
-- Temporary-role mechanism is mid-migration to RBAC; semantics may shift.
+- `LoginHelper` lifecycle methods are `private` and must be extracted before LDAP (and the XML-RPC credential path) can reuse them.
+- RBAC access-group membership has no temporary/externally-managed flag yet, so recomputing LDAP-derived access groups on login needs a design decision (see Unresolved questions #1).
 - LDAP/AD schema variety; v1 documents clear defaults and limits.
 
 # Alternatives
@@ -364,20 +385,25 @@ Findings fed into this RFC: external-group mapping is live; mapping is at the ro
 
 - **Stay on PAM/SSSD only** — no in-product configuration or group mapping. Does not meet the goal.
 - **Improve only `REMOTE_USER`** — auth stays outside Uyuni; no in-product visibility[^4].
-- **LDAP only inside `UserImpl.authenticate()`** — cannot JIT-provision; rejected in favor of `LoginController` orchestration.
+- **LDAP handling *only* inside `UserImpl.authenticate()`** — cannot JIT-provision or map groups; rejected in favor of `LoginController` orchestration. (The credential *check* is still delegated from `UserManager.loginUser`/`UserImpl.authenticate` so XML-RPC login works; provisioning/mapping stay in `LoginHelper`.)
 - **Local → LDAP → PAM cascade** — tries multiple backends per login; rejected as neither robust nor performant.
 - **Implementation choices** — JNDI vs. UnboundID SDK[^9]; bind password in `suseCredentials` vs. plain column (latter rejected).
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-1. **LDAP server per user** — should `rhnUserInfo` also store which directory server an LDAP user belongs to (`ldap_server_id`), or probe all servers in priority order on every LDAP login?
-2. **Scoping external groups to a server** — nullable directory FK on `rhnUserExtGroup` (extending `(label, org_id)` uniqueness), or server-agnostic mappings only?
-3. **Superuser reachability** — may an LDAP group grant the top-level admin role, or remain local-only?
+1. **Marking LDAP-derived RBAC access-group membership** — RBAC access-group membership has no temporary/externally-managed flag today, unlike legacy roles (`temporary='Y'` on `rhnUserGroupMembers`). To recompute LDAP-derived access groups on each login without removing manual grants, do we (a) add a temporary/externally-managed flag to access-group membership, or (b) track LDAP-derived memberships via the ext-group mapping origin and reconcile from that? (Raised by reviewer; RBAC-owner decision.)
+2. **JIT over the XML-RPC path** — an LDAP user who has only ever used the XML-RPC API is not yet provisioned (provisioning runs in the `LoginHelper` lifecycle). Is "must log in once via Web UI/HTTP API to be provisioned" acceptable for v1, or should JIT also run from `UserManager.loginUser`?
+3. **Superuser reachability** — may an LDAP group grant `satellite_admin` (top-level admin), or remain local-only?
 4. **Org assignment for JIT users** — single default org enough for v1, or attribute/group-based mapping needed early?
-5. **Temporary roles under RBAC migration** — target legacy temporary roles for v1 and adapt later, or align with RBAC migration now?
 
-**Settled assumptions (reviewer input):** bind passwords use the existing `suseCredentials` / `PasswordBasedCredentials` storage as-is; migrating to salted credentials is a separate task. Directory CA material is uploaded through the LDAP-specific UI/API (Hub upload pattern, not a shared CA service).
+**Settled assumptions (reviewer input):**
+- **LDAP server per user** — `rhnUserInfo` stores `ldap_server_id` (which directory authenticated/provisioned the user). *Confirmed by mentor.*
+- **Bind DN storage** — bind DN lives on `suseLdapAuthServer` (not `suseCredentials.username`, which is `VARCHAR(64)` and too short); `suseCredentials` holds only the password, using a new `ldap` credential type. Migrating to salted credentials is a separate task.
+- **Group mapping target** — LDAP groups map to RBAC access groups by default; only `org_admin`/`satellite_admin` use legacy `rhnUserGroupType` until they migrate.
+- **`regular_user` auto-join** — overridable per LDAP server via `auto_join_regular_user`.
+- **Directory CA material** — uploaded through the LDAP-specific UI/API (Hub upload pattern, not a shared CA service).
+- **Scoping external groups to a server** — nullable directory FK on `rhnUserExtGroup` (extends `(label, org_id)` uniqueness), enabling per-server mappings while keeping server-agnostic ones.
 
 # References
 [references]: #references


### PR DESCRIPTION
**Rendered version** -> [RFC](https://github.com/SURYAS1306/uyuni-rfc/blob/rfc-native-ldap-authentication/accepted/00000-native-ldap-authentication.md)
## Summary

Native Java LDAP/AD authentication for Uyuni with optional JIT user provisioning and LDAP group → Uyuni role mapping via revived `rhnUserExtGroup` tables.

## Motivation

Replace host-level-only LDAP (PAM/SSSD) and proxy-only external authentication with in-product configuration, testing, and group-aware RBAC mapping.

## Proof of work (community bonding)

- Auth flow mapped: `LoginController` → `LoginHelper` → `UserManager` → `UserImpl`
- LDAP prototype validated using UnboundID SDK against local OpenLDAP fixtures
- Deployment workflow validated on containerized Uyuni (`mvn package`, `mgrctl cp`, Tomcat restart)
- Design aligned with mentor feedback (login order, failure modes, table reuse, RBAC scope)

## Open design questions for reviewers

See **Unresolved questions** in the RFC (six design-level items). Feedback especially welcome on secret and trust-material handling, scoping external groups to a server, superuser reachability, and JIT org assignment.

## Related links

- GSoC proposal: Native LDAP authentication provider
- Mentor references: RBAC RFC #95, Spacewalk/IPA wiki, RBAC Endpoint Mapping wiki, Satellite 6 LDAP references