### PR TITLE
Enable Stale GitHub action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Stale PRs
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Label/close stale PRs
+        uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 #v10.1.0
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+
+          # Stale after 120 days (4 months), close after further 30 days
+          days-before-pr-stale: 120
+          days-before-pr-close: 10
+
+          # Don't work on issues (only PRs)
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Delete its branch after closing a PR
+          delete-branch: false


### PR DESCRIPTION
As discussed at the retrospective:
- Stale after 4 months with no changes on the PR at all
- Close after 1 month with ho changes on the PR at all

Related: https://github.com/SUSE/spacewalk/issues/26803